### PR TITLE
cookiecutter.version missing from .bumpversion

### DIFF
--- a/{{cookiecutter.repo_name}}/.bumpversion.cfg
+++ b/{{cookiecutter.repo_name}}/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = {{ cookiecutter.version }}
 files = setup.py src/{{ cookiecutter.package_name }}/__init__.py
 commit = True
 tag = False


### PR DESCRIPTION
Hi, I noticed the {{ cookiecutter.version }} was missing from the bumpversion.cfg file.
