### PR TITLE
Use readthedocs sphinx theme

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -26,10 +26,6 @@ author = {{ '{0!r}'.format(cookiecutter.full_name) }}
 copyright = '{0}, {1}'.format(year, author)
 version = release = {{ '{0!r}'.format(cookiecutter.version) }}
 
-import sphinx_py3doc_enhanced_theme
-html_theme = "sphinx_py3doc_enhanced_theme"
-html_theme_path = [sphinx_py3doc_enhanced_theme.get_html_theme_path()]
-
 pygments_style = 'trac'
 templates_path = ['.']
 html_use_smartypants = True
@@ -39,6 +35,12 @@ html_sidebars = {
    '**': ['searchbox.html', 'globaltoc.html', 'sourcelink.html'],
 }
 html_short_title = '%s-%s' % (project, version)
-html_theme_options = {
-    'githuburl': 'https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/'
-}
+
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+

--- a/{{cookiecutter.repo_name}}/docs/requirements.txt
+++ b/{{cookiecutter.repo_name}}/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 sphinxcontrib-napoleon
-sphinx-py3doc-enhanced-theme
+sphinx_rtd_theme
 -e .


### PR DESCRIPTION
Since you already have the readthedocs badge in the readme, I assume it is desirable to use the readthedocs theme locally too see how it will turn out before pushing. The whole ``on_rtd`` business is [a documented fix](https://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs).