### PR TITLE
use CFLAGS=-coverage for current package only, not deps

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -139,7 +139,7 @@ setenv =
     WITH_COVERAGE=yes
 {%- endraw -%}
 {%- if cookiecutter.c_extension_support|lower == "yes" %}
-    PY_CCOV=-coverage
+    SETUPPY_CFLAGS=-coverage
 {%- endif %}
 {%- raw %}
 usedevelop = true

--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -139,7 +139,7 @@ setenv =
     WITH_COVERAGE=yes
 {%- endraw -%}
 {%- if cookiecutter.c_extension_support|lower == "yes" %}
-    CFLAGS=-coverage
+    PY_CCOV=-coverage
 {%- endif %}
 {%- raw %}
 usedevelop = true

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -36,7 +36,7 @@ def read(*names, **kwargs):
 
 # enable code coverage for C code
 # We can't use CFLAGS=-coverage in tox.ini, since that may mess with
-# compiling dependencies (e.g. numpy). Therefore we set PY_CCOV=-coverage
+# compiling dependencies (e.g. numpy). Therefore we set SETUPPY_CFLAGS=-coverage
 # in tox.ini and copy it to CFLAGS here (after deps have been installed)
 if 'TOXENV' in os.environ and 'SETUPPY_CFLAGS' in os.environ:
     os.environ['CFLAGS'] = os.environ['SETUPPY_CFLAGS']

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -38,7 +38,7 @@ def read(*names, **kwargs):
 # We can't use CFLAGS=-coverage in tox.ini, since that may mess with
 # compiling dependencies (e.g. numpy). Therefore we set PY_CCOV=-coverage
 # in tox.ini and copy it to CFLAGS here (after deps have been installed)
-if 'SETUPPY_CFLAGS' in os.environ.keys():
+if 'TOXENV' in os.environ and 'SETUPPY_CFLAGS' in os.environ:
     os.environ['CFLAGS'] = os.environ['PY_CCOV']
 
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -34,6 +34,14 @@ def read(*names, **kwargs):
     ).read()
 
 
+# enable code coverage for C code
+# We can't use CFLAGS=-coverage in tox.ini, since that may mess with
+# compiling dependencies (e.g. numpy). Therefore we set PY_CCOV=-coverage
+# in tox.ini and copy it to CFLAGS here (after deps have been installed)
+if 'PY_CCOV' in os.environ.keys():
+    os.environ['CFLAGS'] = os.environ['PY_CCOV']
+
+
 {% if cookiecutter.c_extension_support|lower == 'yes' and cookiecutter.c_extension_optional|lower == 'yes' -%}
 class optional_build_ext(build_ext):
     '''Allow the building of C extensions to fail.'''

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -38,7 +38,7 @@ def read(*names, **kwargs):
 # We can't use CFLAGS=-coverage in tox.ini, since that may mess with
 # compiling dependencies (e.g. numpy). Therefore we set PY_CCOV=-coverage
 # in tox.ini and copy it to CFLAGS here (after deps have been installed)
-if 'PY_CCOV' in os.environ.keys():
+if 'SETUPPY_CFLAGS' in os.environ.keys():
     os.environ['CFLAGS'] = os.environ['PY_CCOV']
 
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -39,7 +39,7 @@ def read(*names, **kwargs):
 # compiling dependencies (e.g. numpy). Therefore we set PY_CCOV=-coverage
 # in tox.ini and copy it to CFLAGS here (after deps have been installed)
 if 'TOXENV' in os.environ and 'SETUPPY_CFLAGS' in os.environ:
-    os.environ['CFLAGS'] = os.environ['PY_CCOV']
+    os.environ['CFLAGS'] = os.environ['SETUPPY_CFLAGS']
 
 
 {% if cookiecutter.c_extension_support|lower == 'yes' and cookiecutter.c_extension_optional|lower == 'yes' -%}


### PR DESCRIPTION
See https://github.com/ionelmc/cookiecutter-pylibrary/issues/29#issuecomment-144953556

Build where this fix was introduced:
* [travis](https://travis-ci.org/cmeeren/aacgmv2/builds/83277337)
* [codecov](https://codecov.io/github/cmeeren/aacgmv2?ref=2bb8c0655cd6ceabc4ad152a638f5cac384b671b&view=all)

Build where `CFLAGS=-coverage` was removed entirely:
* [travis](https://travis-ci.org/cmeeren/aacgmv2/builds/83255645)
* [codecov](https://codecov.io/github/cmeeren/aacgmv2?ref=3180a43c812bc251159a6455cb1deed390a34192&view=all)

Build where `CFLAGS=-coverage` was present and numpy install failed:
* [travis](https://travis-ci.org/cmeeren/aacgmv2/builds/83117034)
