### PR TITLE
Improve .travis.yml build matrix

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -15,14 +15,10 @@ env:
     - TOXENV={{ env }}-nocov
 {% endfor %}
 before_install:
-  - python --version
-  - uname -a
-  - lsb_release -a
+  - easy_install --version
 install:
   - pip install tox
   - virtualenv --version
-  - easy_install --version
-  - pip --version
   - tox --version
 script:
   - tox -v

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -1,6 +1,9 @@
-language: python
-python: '3.5'
 sudo: false
+language: python
+python:
+{% for env in ['2.6', '2.7', '3.3', '3.4', '3.5', 'pypy'] %}
+  - "{{ env }}"
+{% endfor %}
 env:
 {% if cookiecutter.c_extension_support|lower == "yes" %}
   global:
@@ -8,28 +11,33 @@ env:
     - SEGFAULT_SIGNALS="abrt segv"
 {% endif %}
   matrix:
-    - TOXENV=check
-{% for env in ['2.6', '2.7', '3.3', '3.4', '3.5', 'pypy'] %}
-    - TOXENV={{ env }}-cover
+    - COVERAGE=cover
       {%- if cookiecutter.coveralls|lower == 'yes' %}
         {%- if cookiecutter.c_extension_support|lower == "yes" %},extension-coveralls{% endif %},coveralls
       {%- endif %}
       {%- if cookiecutter.codecov|lower == 'yes' %},codecov{% endif %}
-    - TOXENV={{ env }}-nocov
-{% endfor %}
+    - COVERAGE=nocov
+matrix:
+  include:
+    - python: "3.4"
+      env: TOXENV=check
+
 before_install:
   - easy_install --version
 install:
   - pip install tox
   - virtualenv --version
   - tox --version
+
+before_script:
+  - export TOXENV=${TOXENV:-$TRAVIS_PYTHON_VERSION-$COVERAGE}
 script:
   - tox -v
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat
+
 notifications:
   email:
     on_success: never
     on_failure: always
-

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -26,10 +26,14 @@ before_install:
   - easy_install --version
 install:
   - pip install tox
+    {%- if cookiecutter.test_runner|lower == "pytest" %} pytest-travis-fold{% endif %}
   - virtualenv --version
   - tox --version
 
 before_script:
+{% if cookiecutter.test_runner|lower == "pytest" %}
+  - export TOX_TESTENV_PASSENV=TRAVIS
+{% endif %}
   - export TOXENV=${TOXENV:-$TRAVIS_PYTHON_VERSION-$COVERAGE}
 script:
   - tox -v

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -37,6 +37,12 @@ after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat
 
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 notifications:
   email:
     on_success: never

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python: '3.5'
 sudo: false
 env:
+{% if cookiecutter.c_extension_support|lower == "yes" %}
   global:
-    LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - SEGFAULT_SIGNALS="abrt segv"
+{% endif %}
   matrix:
     - TOXENV=check
 {% for env in ['2.6', '2.7', '3.3', '3.4', '3.5', 'pypy'] %}

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -43,6 +43,12 @@ after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat
 
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 notifications:
   email:
     on_success: never

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -34,9 +34,14 @@ before_install:
   - easy_install --version
 install:
   - pip install tox
+    {%- if cookiecutter.test_runner|lower == "pytest" %} pytest-travis-fold{% endif %}
   - virtualenv --version
   - tox --version
 
+{% if cookiecutter.test_runner|lower == "pytest" %}
+before_script:
+  - export TOX_TESTENV_PASSENV=TRAVIS
+{% endif %}
 script:
   - tox -v
 after_failure:

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python: '3.5'
 sudo: false
 env:
+{% if cookiecutter.c_extension_support|lower == "yes" %}
   global:
-    LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - SEGFAULT_SIGNALS="abrt segv"
+{% endif %}
   matrix:
     - TOXENV=check
 {% if cookiecutter.test_matrix_configurator == "yes" %}

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -27,14 +27,10 @@ env:
 {%- endraw %}
 {% endif %}
 before_install:
-  - python --version
-  - uname -a
-  - lsb_release -a
+  - easy_install --version
 install:
   - pip install tox
   - virtualenv --version
-  - easy_install --version
-  - pip --version
   - tox --version
 script:
   - tox -v

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -1,6 +1,6 @@
-language: python
-python: '3.5'
 sudo: false
+language: python
+python: "3.4"
 env:
 {% if cookiecutter.c_extension_support|lower == "yes" %}
   global:
@@ -29,17 +29,20 @@ env:
 {% endfor %}
 {%- endraw %}
 {% endif %}
+
 before_install:
   - easy_install --version
 install:
   - pip install tox
   - virtualenv --version
   - tox --version
+
 script:
   - tox -v
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
First and foremost, thank you for the comprehensive template.

This PR improves the way a build matrix is constructed for different Python versions. Instead of having just a single `TOXENV` axis defining a 1D matrix like this:
```yaml
env:
  matrix:
    - TOXENV=check

    - TOXENV=2.6-cover,codecov
    - TOXENV=2.6-nocov

    - TOXENV=2.7-cover,codecov
    - TOXENV=2.7-nocov

    ...
```

... use distinct Python versions as an additional axis, in a natural way for Travis CI:
```yaml
python:
  - "2.6"
  - "2.7"
  ...
env:
  matrix:
    - COVERAGE=cover,codecov
    - COVERAGE=nocov
```

... and infer `TOXENV` from that:
```yaml
before_script:
  - export TOXENV=${TOXENV:-$TRAVIS_PYTHON_VERSION-$COVERAGE}
```

This makes the Travis UI look better since true Python versions are shown for each build row. A similar change has been merged into a pytest-plugin cookiecutter template recently: pytest-dev/cookiecutter-pytest-plugin#13

Also make few less important changes, mostly cleanup.

NB: The last commit adds installation of [pytest-travis-fold](https://github.com/abusalimov/pytest-travis-fold), which in turn may be considered as self-advertising (I'm the author of the plugin). If you believe this is inappropriate, please let me know, and I will drop that commit.