### PR TITLE
Change index.rst main heading

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/index.rst
+++ b/{{cookiecutter.repo_name}}/docs/index.rst
@@ -1,7 +1,6 @@
-Welcome to {{ cookiecutter.project_name }}'s documentation!
-{{ "=" * (30 + cookiecutter.project_name|length) }}
-
-Contents:
+========
+Contents
+========
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
With this change, the title (html title, shown in search engines) on the main ReadTheDocs page (projectname.readthedocs.org) is:

"Contents - \<projectname\> \<version\> documentation"

instead of the rather wordy and self-repeating:

 "Welcome to \<projectname\>'s documentation - \<projectname\> \<version\> documentation"

This is just a suggestion, and there may be better ways to fix the page title. I like it though, because the package name is (using the default RTD style) always in the upper left corner anyway, and people probably don't need to be told that this is, in fact, the packages documentation (as opposed to what? :P )

I'm not 100% sure the heading level is correct though.