### PR TITLE
Move badges to the bottom of README.rst

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -2,6 +2,34 @@
 {{ cookiecutter.project_name }}
 {{ "=" * cookiecutter.project_name|length }}
 
+|docs| |version|
+
+{{ cookiecutter.project_short_description|wordwrap(140) }}
+
+* Free software: BSD license
+
+Installation
+============
+
+::
+
+    pip install {{ cookiecutter.distribution_name }}
+
+Documentation
+=============
+
+https://{{ cookiecutter.repo_name }}.readthedocs.org/
+
+Development
+===========
+
+To run the all tests run::
+
+    tox
+
+Badges
+======
+
 .. list-table::
     :stub-columns: 1
 
@@ -91,26 +119,3 @@
     :alt: Scrutinizer Status
     :target: https://scrutinizer-ci.com/g/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/
 {% endif %}
-
-{{ cookiecutter.project_short_description|wordwrap(140) }}
-
-* Free software: BSD license
-
-Installation
-============
-
-::
-
-    pip install {{ cookiecutter.distribution_name }}
-
-Documentation
-=============
-
-https://{{ cookiecutter.repo_name }}.readthedocs.org/
-
-Development
-===========
-
-To run the all tests run::
-
-    tox


### PR DESCRIPTION
Just a suggestion. I don't like seeing lots and lots of badges at the top of the page. The only really important badges for the end user IMHO are docs (for obvious reasons) and pypi version (to direct the user to pypi if encountered elsewhere), though even pypi could be removed from the top since it's in the install instructions anyway. The rest can safely be moved to the bottom, for easy access whilst avoiding the "in your face" feeling you get from the gargantuan badge table when it's at the top.