### PR TITLE
Update heading in README.rst

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -1,6 +1,6 @@
-{{ "=" * cookiecutter.project_name|length }}
-{{ cookiecutter.project_name }}
-{{ "=" * cookiecutter.project_name|length }}
+========
+Overview
+========
 
 .. list-table::
     :stub-columns: 1

--- a/{{cookiecutter.repo_name}}/docs/readme.rst
+++ b/{{cookiecutter.repo_name}}/docs/readme.rst
@@ -1,5 +1,1 @@
-########
-Overview
-########
-
 .. include:: ../README.rst


### PR DESCRIPTION
Since README.rst is included in docs/index.rst, the heading will be shown in the ReadTheDocs menu. I don't think the project name is especially informative as a title in the menu, so I'm using "Overview" here in my packages. The package name is shown at the top on PyPI anyway.

Just a suggestion. :)