### PR TITLE
Update napoleon config

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -58,3 +58,6 @@ html_sidebars = {
    '**': ['searchbox.html', 'globaltoc.html', 'sourcelink.html'],
 }
 html_short_title = '%s-%s' % (project, version)
+
+napoleon_use_ivar=True
+napoleon_use_rtype=False


### PR DESCRIPTION
``napoleon_use_ivar=True`` will make class attributes look like the parameters section instead of looking like methods.

``napoleon_use_rtype=False`` will make the return type inline, which gives a consistent look between functions with multiple returns (where the type is always inline) and functions with single returns (where the return type is on its own by default).

Attributes ``year``, ``refh``, ``datafile`` looking like methods (default):

![use_ivar_false](https://cloud.githubusercontent.com/assets/7766733/11419599/d194db10-9428-11e5-9dd2-fbdc1aa3c35b.png)

Attributes looking like parameters (proposed change):

![use_ivar_true](https://cloud.githubusercontent.com/assets/7766733/11419601/d1968988-9428-11e5-8bae-498abe3748c9.png)

Return type in its own section when one variable is returned, and inline if multiple variables are returned (default):

![use_rtype_true](https://cloud.githubusercontent.com/assets/7766733/11419602/d197c88e-9428-11e5-8839-49b9414e3bfe.png)

Return type always inline for consistency (proposed change):

![use_rtype_false](https://cloud.githubusercontent.com/assets/7766733/11419600/d195de0c-9428-11e5-9022-a812102cccbf.png)
