### PR TITLE
Specify "code contributions"

### DIFF
--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -30,7 +30,7 @@ If you are proposing a feature:
 
 * Explain in detail how it would work.
 * Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that contributions are welcome :)
+* Remember that this is a volunteer-driven project, and that code contributions are welcome :)
 
 Development
 ===========


### PR DESCRIPTION
If you mean "code contributions", I think that should be clarified here. When reading it without the clarification I get the impression that e.g. donations are welcome.

I have no idea what's up with the "detox" line, I did absolutely not change that (it happened twice, must be a GH bug).