### PR TITLE
Remove several references to python 2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Features
 This is an "all inclusive" sort of template.
 
 * BSD 2-clause license.
-* Tox_ for managing test environments for Python 2.6, 2.7, 3.3, PyPy etc.
-* Pytest_ or Nose_ for testing Python 2.6, 2.7, 3.3, PyPy etc.
+* Tox_ for managing test environments for Python 2.7, 3.3, PyPy etc.
+* Pytest_ or Nose_ for testing Python 2.7, 3.3, PyPy etc.
 * *Optional* support for creating a tests matrix out of dependencies and python versions.
 * Travis-CI_ and AppVeyor_ for continuous testing.
 * Coveralls_ or Codecov_ for coverage tracking (using Tox_).

--- a/{{cookiecutter.repo_name}}/ci/appveyor-bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/appveyor-bootstrap.py
@@ -18,8 +18,6 @@ BASE_URL = "https://www.python.org/ftp/python/"
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 GET_PIP_PATH = "C:\get-pip.py"
 URLS = {
-    ("2.6", "64"): BASE_URL + "2.6.6/python-2.6.6.amd64.msi",
-    ("2.6", "32"): BASE_URL + "2.6.6/python-2.6.6.msi",
     ("2.7", "64"): BASE_URL + "2.7.10/python-2.7.10.amd64.msi",
     ("2.7", "32"): BASE_URL + "2.7.10/python-2.7.10.msi",
     # NOTE: no .msi installer for 3.3.6
@@ -32,8 +30,6 @@ URLS = {
 }
 INSTALL_CMD = {
     # Commands are allowed to fail only if they are not the last command.  Eg: uninstall (/x) allowed to fail.
-    "2.6": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
     "2.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
     "3.3": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -29,7 +29,6 @@ envlist =
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    py26: {env:TOXPYTHON:python2.6}
     {py27,docs,spell}: {env:TOXPYTHON:python2.7}
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
@@ -150,9 +149,6 @@ commands = coverage erase
 skip_install = true
 usedevelop = false
 deps = coverage
-
-[testenv:py26-nocov]
-usedevelop = false
 
 [testenv:py27-nocov]
 usedevelop = false


### PR DESCRIPTION
@ionelmc This pull request removes a few references to python 2.6. It's no longer included in the test matrix.

Python 2.6 hasn't been supported by Python core in some time, with the last release being from October 2013.

Thanks for making this incredibly useful template!