### PR TITLE
if no c extension support, dont include "extension-coveralls"

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -33,7 +33,7 @@ basepython =
     py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
-    {clean,check,report,extension-coveralls,coveralls,codecov}: python3.5
+    {clean,check,report,{% if cookiecutter.c_extension_support|lower == "yes" %}extension-coveralls,{% endif %}coveralls,codecov}: python3.5
     bootstrap: python
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
if no c extension support, dont include "extension-coveralls", 
also suppose, if not use coverall, "extension-coveralls" should not be included too.