### PR TITLE
support using unittest as a test runner

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -30,7 +30,7 @@
     "c_extension_optional": ["no", "yes"],
     "test_matrix_configurator": ["no", "yes"],
     "test_matrix_separate_coverage": ["no", "yes"],
-    "test_runner": ["pytest", "nose"],
+    "test_runner": ["pytest", "nose", "unittest"],
     "command_line_interface": ["plain", "click", "no"],
     "command_line_interface_bin_name": "nameless",
     "coveralls": ["no", "yes"],

--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -32,6 +32,8 @@ commands =
 {%- endif %}
 {%- if cookiecutter.test_runner|lower == "pytest" %}
     {posargs:py.test -vv --ignore=src}
+{%- elif cookiecutter.test_runner|lower == "unittest" %}
+    {posargs:python -m unittest discover -v tests}
 {%- else %}
     {posargs:nosetests -v tests}
 {%- endif %}
@@ -154,6 +156,8 @@ commands =
 {%- endif %}
 {%- if cookiecutter.test_runner|lower == "pytest" %}
     {posargs:py.test --cov --cov-report=term-missing -vv}
+{%- elif cookiecutter.test_runner|lower == "unittest" %}
+    {posargs:coverage run --source={{ cookiecutter.package_name|replace('-', '_') }} -m unittest discover -v tests}
 {%- else %}
     {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name|replace('-', '_') }}}
 {%- endif %}
@@ -167,6 +171,8 @@ deps =
 {%- endraw -%}
 {%- if cookiecutter.test_runner|lower == "pytest" %}
     pytest-cov
+{%- elif cookiecutter.test_runner|lower == "unittest" %}
+    coverage
 {%- else %}
     coverage
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -46,6 +46,8 @@ deps =
     pytest
     pytest-travis-fold
     {% if cookiecutter.test_matrix_separate_coverage|lower == 'yes' %}cover: {% endif %}pytest-cov
+{%- elif cookiecutter.test_runner|lower == "unittest" %}
+    {% if cookiecutter.test_matrix_separate_coverage|lower == 'yes' %}cover: {% endif %}coverage
 {%- else %}
     nose
     {% if cookiecutter.test_matrix_separate_coverage|lower == 'yes' %}cover: {% endif %}coverage
@@ -62,6 +64,13 @@ commands =
     cover: {posargs:py.test --cov --cov-report=term-missing -vv}
     {%- else %}
     {posargs:py.test --cov={{ cookiecutter.package_name|replace('-', '_') }} --cov-report=term-missing -vv tests}
+    {%- endif %}
+{%- elif cookiecutter.test_runner|lower == "unittest" %}
+    {%- if cookiecutter.test_matrix_separate_coverage|lower == 'yes' %}
+    nocov: {posargs:python -m unittest discover -v tests}
+    cover: {posargs:coverage run --source={{ cookiecutter.package_name|replace('-', '_') }} -m unittest discover -v tests}
+    {%- else %}
+    {posargs:coverage run --source={{ cookiecutter.package_name|replace('-', '_') }} -m unittest discover -v tests}
     {%- endif %}
 {%- else %}
     {%- if cookiecutter.test_matrix_separate_coverage|lower == 'yes' %}


### PR DESCRIPTION
I'm trying to add support for using the built-in `unittest` module for running tests. Here is the beginning of my attempt.

Questions:
1. Are there additional files I should be editing?
2. Could you explain the reasoning and outcome of the differences in the test running commands, when running with coverage vs. running with coverage in the "split coverage" setting?
3. Do I need to add tests for this? If so, can you point me to similar examples of existing tests?
