### PR TITLE
force isort to check the correct files and directories

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -81,7 +81,7 @@ commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff --recursive src tests setup.py
+    isort --verbose --check-only --diff --recursive {toxinidir}/src {toxinidir}/tests {toxinidir}/setup.py
 {% endraw %}
 [testenv:coveralls]
 deps =

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -116,7 +116,7 @@ commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff --recursive src tests setup.py
+    isort --verbose --check-only --diff --recursive {toxinidir}/src {toxinidir}/tests {toxinidir}/setup.py
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
force isort to check the correct files and directories (this avoid false positive for me) 