### PR TITLE
Partial fix for Sphinx 1.4 build failures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,10 +191,8 @@ You will be asked for these fields:
     * - ``sphinx_theme``
       - .. code:: python
 
-            "readthedocs"
+            "sphinx-rtd-theme"
       - What Sphinx_ theme to use.
-
-        If theme is different than ``"readthedocs"`` then it's also going to be added in ``docs/requirements.txt``.
 
         Suggested alternative: `sphinx-py3doc-enhanced-theme
         <https://pypi.python.org/pypi/sphinx_py3doc_enhanced_theme>` for a responsive theme based on

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -39,7 +39,7 @@
     "scrutinizer": ["no", "yes"],
     "codacy" : ["no", "yes"],
     "codeclimate" : ["no", "yes"],
-    "sphinx_theme": ["readthedocs", "sphinx-py3doc-enhanced-theme"],
+    "sphinx_theme": ["sphinx-rtd-theme", "sphinx-py3doc-enhanced-theme"],
     "sphinx_doctest": ["no", "yes"],
     "travis": ["yes", "no"],
     "appveyor": ["yes", "no"],

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -46,10 +46,8 @@ html_theme_options = {
 # on_rtd is whether we are on readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+if not on_rtd:  # only set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 {%- endif %}
 
 html_use_smartypants = True

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -35,7 +35,7 @@ extlinks = {
     'pr': ('https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/pull/%s', 'PR #'),
 }
 
-{%- if cookiecutter.sphinx_theme|lower != 'readthedocs' %}
+{%- if cookiecutter.sphinx_theme|lower != 'sphinx-rtd-theme' %}
 import {{ cookiecutter.sphinx_theme|replace('-', '_') }}
 html_theme = "{{ cookiecutter.sphinx_theme|replace('-', '_') }}"
 html_theme_path = [{{ cookiecutter.sphinx_theme|replace('-', '_') }}.get_html_theme_path()]

--- a/{{cookiecutter.repo_name}}/docs/requirements.txt
+++ b/{{cookiecutter.repo_name}}/docs/requirements.txt
@@ -1,5 +1,3 @@
 sphinx>=1.3
-{%- if cookiecutter.sphinx_theme|lower != 'readthedocs' %}
 {{ cookiecutter.sphinx_theme|replace('_', '-') }}
-{%- endif %}
 -e .


### PR DESCRIPTION
This is a partial fix for #54. This pull request ensures that `sphinx_rtd_theme` is installed in the docs environment if that was chosen by the user during project generation. I changed the `sphinx_theme` configuration value from `readthedocs` to `sphinx_rtd_theme` because it made the code more consistent and avoided hard-coding in a couple spots, but I understand if that's not the solution that is preferred.

The second commit simplifies the inclusion of `sphinx_rtd_theme`, as `'sphinx_rtd_theme'` is a special value recognized by Sphinx. Feel free to cherry pick, though!

Building the docs is still failing after these changes have been applied, but the issue is no longer with `sphinx_rtd_theme`. See my updated #54 for more information.