### PR TITLE
Improve code style (PEP8) of ``{{cookiecutter.repo_name}}/ci`` scripts.

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/appveyor-bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/appveyor-bootstrap.py
@@ -5,8 +5,10 @@ This is a port of https://github.com/pypa/python-packaging-user-guide/blob/maste
 with various fixes and improvements that just weren't feasible to implement in PowerShell.
 """
 from __future__ import print_function
+
 from os import environ
 from os.path import exists
+from subprocess import CalledProcessError
 from subprocess import check_call
 
 try:
@@ -67,7 +69,7 @@ def install_python(version, arch, home):
         print("Running:", " ".join(cmd))
         try:
             check_call(cmd)
-        except Exception as exc:
+        except CalledProcessError as exc:
             print("Failed command", cmd, "with:", exc)
             if exists("install.log"):
                 with open("install.log") as fh:

--- a/{{cookiecutter.repo_name}}/ci/appveyor-download.py
+++ b/{{cookiecutter.repo_name}}/ci/appveyor-download.py
@@ -10,8 +10,9 @@ from __future__ import unicode_literals
 
 import argparse
 import os
-import requests
 import zipfile
+
+import requests
 
 
 def make_auth_headers():
@@ -64,7 +65,7 @@ def download_latest_artifacts(account_project, build_id):
 
 def ensure_dirs(filename):
     """Make sure the directories exist for `filename`."""
-    dirname, _ = os.path.split(filename)
+    dirname = os.path.dirname(filename)
     if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
 
@@ -89,6 +90,7 @@ def unpack_zipfile(filename):
             print(u"      extracting {}".format(name))
             ensure_dirs(name)
             z.extract(name)
+
 
 parser = argparse.ArgumentParser(description='Download artifacts from AppVeyor.')
 parser.add_argument('--id',

--- a/{{cookiecutter.repo_name}}/ci/bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/bootstrap.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import sys
+from os.path import abspath
+from os.path import dirname
 from os.path import exists
 from os.path import join
-from os.path import dirname
-from os.path import abspath
 
 
 if __name__ == "__main__":
@@ -20,14 +20,16 @@ if __name__ == "__main__":
         bin_path = join(env_path, "bin")
     if not exists(env_path):
         import subprocess
+
         print("Making bootstrap env in: {0} ...".format(env_path))
         try:
             subprocess.check_call(["virtualenv", env_path])
-        except Exception:
+        except subprocess.CalledProcessError:
             subprocess.check_call([sys.executable, "-m", "virtualenv", env_path])
-        print("Installing `jinja2` {% if cookiecutter.test_matrix_configurator == "yes" %}and `matrix` {% endif %}into bootstrap environment ...")
+        print("Installing `jinja2` {% if cookiecutter.test_matrix_configurator == "yes" %}and `matrix` {% endif %}into bootstrap environment...")
         subprocess.check_call([join(bin_path, "pip"), "install", "jinja2"{% if cookiecutter.test_matrix_configurator == "yes" %}, "matrix"{% endif %}])
     activate = join(bin_path, "activate_this.py")
+    # noinspection PyCompatibility
     exec(compile(open(activate, "rb").read(), activate, "exec"), dict(__file__=activate))
 
     import jinja2
@@ -36,7 +38,6 @@ if __name__ == "__main__":
 {% else %}
     import subprocess
 {% endif %}
-
     jinja = jinja2.Environment(
         loader=jinja2.FileSystemLoader(join(base_path, "ci", "templates")),
         trim_blocks=True,
@@ -48,27 +49,24 @@ if __name__ == "__main__":
     for (alias, conf) in matrix.from_file(join(base_path, "setup.cfg")).items():
         python = conf["python_versions"]
         deps = conf["dependencies"]
-        if "coverage_flags" in conf:
-            cover = {"false": False, "true": True}[conf["coverage_flags"].lower()]
-        if "environment_variables" in conf:
-            env_vars = conf["environment_variables"]
-
         tox_environments[alias] = {
             "python": "python" + python if "py" not in python else python,
             "deps": deps.split(),
         }
         if "coverage_flags" in conf:
+            cover = {"false": False, "true": True}[conf["coverage_flags"].lower()]
             tox_environments[alias].update(cover=cover)
         if "environment_variables" in conf:
+            env_vars = conf["environment_variables"]
             tox_environments[alias].update(env_vars=env_vars.split())
 {% else %}
     tox_environments = [
         line.strip()
+        # WARNING: 'tox' must be installed globally or in the project's virtualenv
         for line in subprocess.check_output(['tox', '--listenvs'], universal_newlines=True).splitlines()
     ]
     tox_environments = [line for line in tox_environments if line not in ['clean', 'report', 'docs', 'check']]
 {% endif %}
-
     for name in os.listdir(join("ci", "templates")):
         with open(join(base_path, name), "w") as fh:
             fh.write(jinja.get_template(name).render(tox_environments=tox_environments))


### PR DESCRIPTION
The generated ``ci`` scripts appears to have some awkwardness:

- too broad exception catching (when calling ``check_output`` or ``check_call``).
- PEP8 warnings: order of imports, newlines.
- local variable may not be defined (when checking "coverage_flags" and "environment_variables" in ``conf``).

Also notice that: ``python ci/bootstrap.py`` won't work if ``tox`` isn't installed globally or in the project's virtualenv, (in my environment, I use an ``alias`` for ``tox``). So, I add a warning.

Enjoy.
