### PR TITLE
Template fix: missing entry point if "argparse" and config for "nosetests"

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -7,6 +7,7 @@ universal = 1
 max-line-length = 140
 exclude = tests/*,*/migrations/*,*/south_migrations/*
 
+{% if cookiecutter.test_runner|lower == "pytest" -%}
 [pytest]
 norecursedirs =
     .git
@@ -33,6 +34,14 @@ addopts =
     --doctest-glob=\*.rst
     --tb=short
 
+{%- elif cookiecutter.test_runner|lower == "nose" -%}
+[nosetests]
+verbosity = 2
+with-coverage = 1
+cover-package = {{ cookiecutter.package_name|replace('-', '_') }}
+where = tests/
+
+{% endif -%}
 [isort]
 force_single_line=True
 line_length=120

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -137,7 +137,7 @@ setup(
         'cython',
     ] if Cython else [],
 {%- endif %}
-{%- if cookiecutter.command_line_interface|lower in ['plain', 'click'] %}
+{%- if cookiecutter.command_line_interface|lower != 'no' %}
     entry_points={
         'console_scripts': [
             '{{ cookiecutter.command_line_interface_bin_name }} = {{ cookiecutter.package_name|replace('-', '_') }}.cli:main',

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -65,10 +65,10 @@ commands =
     {%- endif %}
 {%- else %}
     {%- if cookiecutter.test_matrix_separate_coverage|lower == 'yes' %}
-    nocov: {posargs:nosetests -v tests}
+    nocov: {posargs:nosetests -v}
     cover: {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name|replace('-', '_') }}}
     {%- else %}
-    {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name|replace('-', '_')}} tests}
+    {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name|replace('-', '_')}}}
     {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
I change the ``setup.py`` to generate the console script entry point in "argparse" is chosen (not only "plain" or "click").

I add a section for ``nosetests`` in ``setup.cfg`` if "nose" if chosen and remove the ``pytest`` section.

I fix the ``nosetests`` command in ``tox.ini``: "tests" is removed because it is interpreted as being a package instead of a directory.
