### PR TITLE
Add trailing minus to remove blank newline

### DIFF
--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name.replace('-','_')}}/cli.py
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name.replace('-','_')}}/cli.py
@@ -51,4 +51,4 @@ def main(argv=sys.argv):
 
     print(argv)
     return 0
-{%- endif %}
+{%- endif -%}


### PR DESCRIPTION
This should fix issue #66, and I've tested locally, just hard to tell if it's a missing \n on 53 or whether 54 removes the \n on 53 when it removes itself which causes one of the PEP issues.