### PR TITLE
Fix twine examples in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -382,8 +382,8 @@ And then you can build the ``sdist``, and if possible, the ``bdist_wheel`` too::
 
 To make a release of the project on PyPI, assuming you got some distributions in ``dist/``, the most simple usage is::
 
-    twine register dist/*
-    twine upload --skip-existing dist/*
+    for dist in dist/*.gz dist/*.whl; do twine register $dist; done
+    for dist in dist/*.gz dist/*.whl; do twine upload --skip-existing $dist; done
 
 Note:
 


### PR DESCRIPTION
Twine doesn't take multiple packages as arguments. Also, you will have `docs` in `dist` after following the README. So the example twine commands don't work.

I guess the commands from this PR will not work with the standard Windows shell. Not sure if you want to support that, or if we can assume a UNIX shell.