### PR TITLE
Fix redirect warning for tox.readthedocs.org -> tox.readthedocs.io 

### DIFF
--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ To set up `{{ cookiecutter.repo_name }}` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <http://tox.readthedocs.org/en/latest/install.html>`_ one command::
+4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <http://tox.readthedocs.io/en/latest/install.html>`_ one command::
 
     tox
 


### PR DESCRIPTION
Running `$ tox -e docs` warns about a permanent redirect:

```
writing output... [ 33%] contributing
...
(line   52) redirect  http://tox.readthedocs.org/en/latest/install.html\
 - permanently to http://tox.readthedocs.io/en/latest/install.html
...
```

This change fixes it:

```
(line   52) ok        http://tox.readthedocs.io/en/latest/install.html
```