### PR TITLE
Fix for BSD sed on MacOS

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -7,6 +7,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# A safer way to invoke 'sed', compensates for the difference between BSD and GNU sed. 
+# https://stackoverflow.com/a/38595160/1950432
+safe_sed () {
+    sed --version > /dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+}
+
 echo "\033[1;36m================================\033[0m"
 echo "\033[1;36m================================ Testing: $1\033[0m"
 echo "\033[1;36m================================\033[0m"
@@ -24,5 +30,5 @@ git commit -m "initial."
 bumpversion patch
 bumpversion minor
 bumpversion major
-sed -i 's/sphinx-build -b linkcheck/#/' tox.ini
+safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
 tox


### PR DESCRIPTION
This should fix the incorrect behaviour of the tox tests on MacOS.