### PR TITLE
Fix license not being set correctly in setup script

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -82,7 +82,7 @@ class optional_build_ext(build_ext):
 setup(
     name='{{ cookiecutter.distribution_name }}',
     version='{{ cookiecutter.version }}',
-    license='BSD',
+    license='{{ cookiecutter.license }}',
     description={{ '{0!r}'.format(cookiecutter.project_short_description).lstrip('ub') }},
     long_description='%s\n%s' % (
         re.compile('^.. start-badges.*^.. end-badges', re.M | re.S).sub('', read('README.rst')),
@@ -100,7 +100,15 @@ setup(
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
+{%- if cookiecutter.license == "BSD license" %}
         'License :: OSI Approved :: BSD License',
+{%- elif cookiecutter.license == "MIT license" %}
+        'License :: OSI Approved :: MIT License',
+{% elif cookiecutter.license == "ISC license" %}
+        'License :: OSI Approved :: ISC License (ISCL)',
+{% else %}
+        'License :: OSI Approved :: Apache Software License',
+{% endif -%}
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
Regardless of what license you pick in the cookiecutter dialog, the resulting setup.py script specifies the license as "BSD"