### PR TITLE
Remove python 3.3 as its past end-of-life

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TOXENV=docs
 matrix:
   include:
-{%- for env in ['py27', 'py33', 'py34', 'py35', 'py36', 'pypy'] %}
+{%- for env in ['py27', 'py34', 'py35', 'py36', 'pypy'] %}
     - python: '{{ '{0[0]}-5.4'.format(env.split('-')) if env.startswith('pypy') else '{0[2]}.{0[3]}'.format(env) }}'
       env:
         - TOXENV={{ env }}{% if cookiecutter.test_matrix_separate_coverage == 'yes' or cookiecutter.test_matrix_configurator == 'yes' %}-cover{% endif %},report

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       PYTHON_HOME: C:\Python27
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '32'
-{%- for env in ['py27', 'py33', 'py34', 'py35', 'py36'] %}{{ '' }}
+{%- for env in ['py27', 'py34', 'py35', 'py36'] %}{{ '' }}
     - TOXENV: '{{ env }}{% if cookiecutter.test_matrix_separate_coverage == 'yes' or cookiecutter.test_matrix_configurator == 'yes' %}-cover{% endif -%},report
       {#- if cookiecutter.coveralls == 'yes' %},coveralls{% endif -#}
       {%- if cookiecutter.codecov == 'yes' %},codecov{% endif %}'
@@ -23,7 +23,7 @@ environment:
       {#- if cookiecutter.coveralls == 'yes' %},coveralls{% endif -#}
       {%- if cookiecutter.codecov == 'yes' %},codecov{% endif %}'
       TOXPYTHON: C:\Python{{ env[2:4] }}-x64\python.exe
-      {% if env.startswith(('py2', 'py33', 'py34')) -%}
+      {% if env.startswith(('py2', 'py34')) -%}
       WINDOWS_SDK_VERSION: v7.{{ '1' if env.startswith('py3') else '0' }}
       {% endif -%}
       PYTHON_HOME: C:\Python{{ env[2:4] }}-x64
@@ -37,7 +37,7 @@ environment:
       PYTHON_ARCH: '32'
     - TOXENV: '{{ env }}-nocov'
       TOXPYTHON: C:\Python{{ env[2:4] }}-x64\python.exe
-      {% if env.startswith(('py2', 'py33', 'py34')) -%}
+      {% if env.startswith(('py2', 'py34')) -%}
       WINDOWS_SDK_VERSION: v7.{{ '1' if env.startswith('py3') else '0' }}
       {% endif -%}
       PYTHON_HOME: C:\Python{{ env[2:4] }}-x64

--- a/{{cookiecutter.repo_name}}/ci/appveyor-bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/appveyor-bootstrap.py
@@ -20,9 +20,6 @@ GET_PIP_PATH = "C:\get-pip.py"
 URLS = {
     ("2.7", "64"): BASE_URL + "2.7.13/python-2.7.13.amd64.msi",
     ("2.7", "32"): BASE_URL + "2.7.13/python-2.7.13.msi",
-    # NOTE: no .msi installer for 3.3.6
-    ("3.3", "64"): BASE_URL + "3.3.5/python-3.3.5.amd64.msi",
-    ("3.3", "32"): BASE_URL + "3.3.5/python-3.3.5.msi",
     ("3.4", "64"): BASE_URL + "3.4.4/python-3.4.4.amd64.msi",
     ("3.4", "32"): BASE_URL + "3.4.4/python-3.4.4.msi",
     ("3.5", "64"): BASE_URL + "3.5.4/python-3.5.4-amd64.exe",
@@ -33,8 +30,6 @@ URLS = {
 INSTALL_CMD = {
     # Commands are allowed to fail only if they are not the last command.  Eg: uninstall (/x) allowed to fail.
     "2.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "3.3": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
     "3.4": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],

--- a/{{cookiecutter.repo_name}}/ci/templates/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/appveyor.yml
@@ -64,7 +64,7 @@ environment:
     {%- endif -%}
 {%- raw %}'
       TOXPYTHON: C:\Python{{ env[2:4] }}-x64\python.exe
-      {%- if env.startswith(('py2', 'py33', 'py34')) %}
+      {%- if env.startswith(('py2', 'py34')) %}
 
       WINDOWS_SDK_VERSION: v7.{{ '1' if env.startswith('py3') else '0' }}
       {%- endif %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -118,7 +118,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -22,7 +22,7 @@ passenv =
 envlist =
     {% if cookiecutter.test_runner == "pytest" %}clean,{% endif %}
     check,
-    {py27,py33,py34,py35,py36,pypy}{% if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
+    {py27,py34,py35,py36,pypy}{% if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
     {% if cookiecutter.test_runner == "pytest" %}report,{% endif %}
     docs
 
@@ -30,7 +30,6 @@ envlist =
 basepython =
     pypy: {env:TOXPYTHON:pypy}
     {py27,docs,spell}: {env:TOXPYTHON:python2.7}
-    py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
@@ -170,9 +169,6 @@ skip_install = true
 deps = coverage
 {% if cookiecutter.test_matrix_separate_coverage == 'yes' %}
 [testenv:py27-cover]
-usedevelop = true
-
-[testenv:py33-cover]
 usedevelop = true
 
 [testenv:py34-cover]


### PR DESCRIPTION
Python 3.3 reached end-of-life on 2017-09-29.

New projects should not be using end-of-life versions of python.

See the Python [branch status](https://devguide.python.org/#branchstatus).