### PR TITLE
Update tox docs links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -463,7 +463,7 @@ No way, this is the best. :stuck_out_tongue_winking_eye:
 If you have criticism or suggestions please open up an Issue or Pull Request.
 
 .. _Travis-CI: http://travis-ci.org/
-.. _Tox: http://testrun.org/tox/
+.. _Tox: https://tox.readthedocs.io/en/latest/
 .. _Sphinx: http://sphinx-doc.org/
 .. _Coveralls: https://coveralls.io/
 .. _ReadTheDocs: https://readthedocs.org/

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -16,7 +16,7 @@ commands =
 passenv =
     *
 {%- else -%}
-; a generative tox configuration, see: https://testrun.org/tox/en/latest/config.html#generative-envlist
+; a generative tox configuration, see: https://tox.readthedocs.io/en/latest/config.html#generative-envlist
 
 [tox]
 envlist =


### PR DESCRIPTION
https://testrun.org/ is just a squatted domain. Official docs are under https://tox.readthedocs.io/