### PR TITLE
Update PyPI URLs (PyPI migrated to pypi.org)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,7 +192,7 @@ v1.1 (2015-03-28)
 * Added contributing guide for the template.
 * Improved the tests for the template (minor perm and path issues).
 * The ``setup.py release`` doesn't upload anymore. Added instructions for using `twine
-  <https://pypi.python.org/pypi/twine>`_.
+  <https://pypi.org/project/twine>`_.
 * Minor glob simplification in ``MANIFEST.in``.
 
 v1.0 (2015-03-24)

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Projects using this template have these minimal dependencies:
   problem :)
 
 To get quickly started on a new system, just `install setuptools
-<https://pypi.python.org/pypi/setuptools#installation-instructions>`_ and then `install pip
+<https://pypi.org/project/setuptools#installation-instructions>`_ and then `install pip
 <https://pip.pypa.io/en/latest/installing.html>`_. That's the bare minimum to required install Tox_ and Cookiecutter_. To install
 them, just run this in your shell or command prompt::
 
@@ -294,7 +294,7 @@ You will be asked for these fields:
       - What Sphinx_ theme to use.
 
         Suggested alternative: `sphinx-py3doc-enhanced-theme
-        <https://pypi.python.org/pypi/sphinx_py3doc_enhanced_theme>` for a responsive theme based on
+        <https://pypi.org/project/sphinx_py3doc_enhanced_theme>` for a responsive theme based on
         the Python 3 documentation.
 
     * - ``sphinx_doctest``
@@ -424,7 +424,7 @@ For making and uploading `manylinux1 <https://github.com/pypa/manylinux>`_ wheel
 
 Note:
 
-    `twine <https://pypi.python.org/pypi/twine>`_ is a tool that you can use to securely upload your releases to PyPI.
+    `twine <https://pypi.org/project/twine>`_ is a tool that you can use to securely upload your releases to PyPI.
     You can still use the old ``python setup.py register sdist bdist_wheel upload`` but it's not very secure - your PyPI
     password will be sent over plaintext.
 
@@ -473,13 +473,13 @@ If you have criticism or suggestions please open up an Issue or Pull Request.
 .. _Sphinx: http://sphinx-doc.org/
 .. _Coveralls: https://coveralls.io/
 .. _ReadTheDocs: https://readthedocs.org/
-.. _Setuptools: https://pypi.python.org/pypi/setuptools
+.. _Setuptools: https://pypi.org/project/setuptools
 .. _Pytest: http://pytest.org/
 .. _AppVeyor: http://www.appveyor.com/
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _Nose: http://nose.readthedocs.org/
-.. _isort: https://pypi.python.org/pypi/isort
-.. _bumpversion: https://pypi.python.org/pypi/bumpversion
+.. _isort: https://pypi.org/project/isort
+.. _bumpversion: https://pypi.org/project/bumpversion
 .. _Codecov: http://codecov.io/
 .. _Landscape: https://landscape.io/
 .. _Scrutinizer: https://scrutinizer-ci.com/

--- a/{{cookiecutter.repo_name}}/.cookiecutterrc
+++ b/{{cookiecutter.repo_name}}/.cookiecutterrc
@@ -8,7 +8,7 @@
 #    cookiepatcher gh:ionelmc/cookiecutter-pylibrary project-path
 #
 # See:
-#    https://pypi.python.org/pypi/cookiepatcher
+#    https://pypi.org/project/cookiepatcher
 #
 # Alternatively, you can run:
 #

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -76,7 +76,7 @@ Overview
 {% endif %}
 .. |version| image:: https://img.shields.io/pypi/v/{{ cookiecutter.distribution_name }}.svg
     :alt: PyPI Package latest release
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.distribution_name }}
+    :target: https://pypi.org/project/{{ cookiecutter.distribution_name }}
 
 .. |commits-since| image:: https://img.shields.io/github/commits-since/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/v{{ cookiecutter.version }}.svg
     :alt: Commits since latest release
@@ -84,15 +84,15 @@ Overview
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/{{ cookiecutter.distribution_name }}.svg
     :alt: PyPI Wheel
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.distribution_name }}
+    :target: https://pypi.org/project/{{ cookiecutter.distribution_name }}
 
 .. |supported-versions| image:: https://img.shields.io/pypi/pyversions/{{ cookiecutter.distribution_name }}.svg
     :alt: Supported versions
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.distribution_name }}
+    :target: https://pypi.org/project/{{ cookiecutter.distribution_name }}
 
 .. |supported-implementations| image:: https://img.shields.io/pypi/implementation/{{ cookiecutter.distribution_name }}.svg
     :alt: Supported implementations
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.distribution_name }}
+    :target: https://pypi.org/project/{{ cookiecutter.distribution_name }}
 {% if cookiecutter.scrutinizer == 'yes' %}
 .. |scrutinizer| image:: https://img.shields.io/scrutinizer/g/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/master.svg
     :alt: Scrutinizer Status


### PR DESCRIPTION
https://pypi.python.org/pypi/<pkg-name> redirects permanently to https://pypi.org/project/<pkg-name> 