### PR TITLE
Remove redundant settings in tox.ini

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,12 +1,4 @@
-{%- if cookiecutter.test_matrix_configurator == "yes" -%}
-; this is just a bootstrap tox configuration, run tox or ./ci/bootstrap.py to have the full tox.ini
-
-[tox]
-envlist = bootstrap
-
 [testenv:bootstrap]
-basepython =
-    python
 deps =
     jinja2
     matrix
@@ -15,6 +7,17 @@ commands =
     python ci/bootstrap.py
 passenv =
     *
+{% if cookiecutter.test_matrix_configurator == "yes" %}
+basepython =
+    python
+{% endif %}
+
+{%- if cookiecutter.test_matrix_configurator == "yes" -%}
+; this is just a bootstrap tox configuration, run tox or ./ci/bootstrap.py to have the full tox.ini
+
+[tox]
+envlist = bootstrap
+
 {%- else -%}
 ; a generative tox configuration, see: https://tox.readthedocs.io/en/latest/config.html#generative-envlist
 
@@ -81,14 +84,6 @@ commands =
     {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name}} tests}
     {%- endif %}
 {%- endif %}
-
-[testenv:bootstrap]
-deps =
-    jinja2
-    matrix
-skip_install = true
-commands =
-    python ci/bootstrap.py
 
 [testenv:check]
 deps =


### PR DESCRIPTION
This removes a [testenv:bootstrap] section in tox.ini that appears (?) to be completely redundant, duplicating the [testenv:bootstrap] above it so that those settings are in two places (so that changing the settings above has no effect, because they are overridden by the settings below).

The only settings left inside the if-block are the settings that actually depend on if cookiecutter.test_matrix_configurator == "yes".

This uses #118 to pass the Travis CI build.