### PR TITLE
bootstrap tox

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/bootstrap.py
@@ -64,8 +64,12 @@ if __name__ == "__main__":
 {% else %}
     tox_environments = [
         line.strip()
-        # WARNING: 'tox' must be installed globally or in the project's virtualenv
-        for line in subprocess.check_output(['tox', '--listenvs'], universal_newlines=True).splitlines()
+        # 'tox' need not be installed globally, but must be importable
+        # by the Python that is running this script.
+        # This uses sys.executable the same way that the call in
+        # cookiecutter-pylibrary/hooks/post_gen_project.py
+        # invokes this bootstrap.py itself.
+        for line in subprocess.check_output([sys.executable, '-m', 'tox', '--listenvs'], universal_newlines=True).splitlines()
     ]
     tox_environments = [line for line in tox_environments if line.startswith('py')]
 {% endif %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -2,6 +2,7 @@
 deps =
     jinja2
     matrix
+    tox
 skip_install = true
 commands =
     python ci/bootstrap.py


### PR DESCRIPTION
Resolves #121.

Since tox is required by the bootstrap.py script (to run tox --listenvs), this adds tox to the dependencies and then invokes tox the same way it's invoked in https://github.com/ionelmc/cookiecutter-pylibrary/blob/master/hooks/post_gen_project.py.

This relies on #117.