### PR TITLE
Use test runner for setup py test

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -16,6 +16,24 @@ skip = */migrations/*
 max_line_length = 140
 {%- endif %}
 
+[options]
+# tests_require is a list of dependencies that are *absolutely required*
+# to run the tests. tests_require is used when running tests from your
+# *current* Python environment (that is, not using tox).
+# tests_require is ignored by tox.
+# As such, you can usually get away with neglecting tests_require ---
+# it's not a big deal if some of the dependencies get left out.
+# If you're running tests from your current environment, it's because
+# you're actively developing, in which case you usually have an
+# environment you built for development. But if you have to change
+# environments mid-development for any reason, tests_require can save you
+# from getting tripped up.
+# You may also want to have a user run tests on *their* machine, to make
+# sure everything is working.
+# But unless you're in one of those situations, you don't have to worry
+# about tests_require.
+tests_require = {{cookiecutter.test_runner}}
+
 {% if cookiecutter.test_runner == "pytest" -%}
 [tool:pytest]
 # If a pytest section is found in one of the possible config files

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -28,6 +28,8 @@ max_line_length = 140
 # environment you built for development. But if you have to change
 # environments mid-development for any reason, tests_require can save you
 # from getting tripped up.
+# tests_require is used when running tests and debugging through an IDE like
+# PyCharm, to ensure the environment the IDE is using has the requirements.
 # You may also want to have a user run tests on *their* machine, to make
 # sure everything is working.
 # But unless you're in one of those situations, you don't have to worry

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -18,6 +18,10 @@ max_line_length = 140
 
 {% if cookiecutter.test_runner == "pytest" -%}
 [tool:pytest]
+# If a pytest section is found in one of the possible config files
+# (pytest.ini, tox.ini or setup.cfg), then pytest will not look for any others,
+# so if you add a pytest config section elsewhere,
+# you will need to delete this section from setup.cfg.
 {%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}
 norecursedirs =
     .git
@@ -51,8 +55,11 @@ addopts =
 {% elif cookiecutter.test_runner == "nose" -%}
 [nosetests]
 verbosity = 2
-
 {% endif -%}
+
+[aliases]
+test={{cookiecutter.test_runner}} # python setup.py test will defer to this test_runner
+
 [tool:isort]
 force_single_line = True
 line_length = 120

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -167,18 +167,17 @@ setup(
         #   ':python_version=="2.6"': ['argparse'],
     },
     tests_require=['{{cookiecutter.test_runner}}'],
-    setup_requires=(
-        []
+    setup_requires=list(filter(None, [
 {%- if cookiecutter.test_runner == 'pytest' %}
-        + ['pytest-runner']
+        'pytest-runner',
 {% endif %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-        + (['cython'] if Cython else [])
+        ['cython'] if Cython else None,
 {% endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
-        + (['cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [])
+        ['cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else None,
 {% endif %}
-    ),
+    ])),
 {%- if cookiecutter.command_line_interface != 'no' %}
     entry_points={
         'console_scripts': [

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -167,15 +167,25 @@ setup(
         #   ':python_version=="2.6"': ['argparse'],
     },
 {%- if cookiecutter.test_runner == 'pytest' -%}
-{% set cookiecutter.setup_requires_from_test_runner %}'pytest-runner', {% endset %}
+{% set setup_requires_from_test_runner %}
+        'pytest-runner',{% endset %}
 {%- else -%}
-{% set cookiecutter.setup_requires_from_test_runner %}{% endset %}
+{% set setup_requires_from_test_runner %}{% endset %}
 {%- endif -%}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-    setup_requires = [{{cookiecutter.setup_requires_from_test_runner}}'cython'] if Cython else [{{cookiecutter.setup_requires_from_test_runner}}]
+    setup_requires = [{{setup_requires_from_test_runner}}
+        'cython',
+    ] if Cython else [{{setup_requires_from_test_runner}}
+    ]
 {%- elif cookiecutter.c_extension_support == 'cffi' %}
-    setup_requires = [{{cookiecutter.setup_requires_from_test_runner}}'cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [{{cookiecutter.setup_requires_from_test_runner}}],
-{% endif %}
+    setup_requires = [{{setup_requires_from_test_runner}}
+        'cffi>=1.0.0',
+    ] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [{{setup_requires_from_test_runner}}
+    ],
+{%- else %}
+    setup_requires = [{{setup_requires_from_test_runner}}
+    ],
+{%- endif -%}
 {%- if cookiecutter.command_line_interface != 'no' %}
     entry_points={
         'console_scripts': [

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -166,6 +166,7 @@ setup(
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],
     },
+    tests_require=['{{cookiecutter.test_runner}}'],
 {%- if cookiecutter.c_extension_support == 'cython' %}
     setup_requires=[
         'cython',

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -166,17 +166,16 @@ setup(
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],
     },
-    setup_requires=list(filter(None, [
-{%- if cookiecutter.test_runner == 'pytest' %}
-        'pytest-runner',
-{% endif %}
+{%- if cookiecutter.test_runner == 'pytest' -%}
+{% set cookiecutter.setup_requires_from_test_runner %}'pytest-runner', {% endset %}
+{%- else -%}
+{% set cookiecutter.setup_requires_from_test_runner %}{% endset %}
+{%- endif -%}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-        'cython' if Cython else None,
+    setup_requires = [{{cookiecutter.setup_requires_from_test_runner}}'cython'] if Cython else [{{cookiecutter.setup_requires_from_test_runner}}]
+{%- elif cookiecutter.c_extension_support == 'cffi' %}
+    setup_requires = [{{cookiecutter.setup_requires_from_test_runner}}'cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [{{cookiecutter.setup_requires_from_test_runner}}],
 {% endif %}
-{%- if cookiecutter.c_extension_support == 'cffi' %}
-        'cffi>=1.0.0' if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else None,
-{% endif %}
-    ])),
 {%- if cookiecutter.command_line_interface != 'no' %}
     entry_points={
         'console_scripts': [

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -166,7 +166,6 @@ setup(
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],
     },
-    tests_require=['{{cookiecutter.test_runner}}'],
     setup_requires=list(filter(None, [
 {%- if cookiecutter.test_runner == 'pytest' %}
         'pytest-runner',

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -171,10 +171,10 @@ setup(
         'pytest-runner',
 {% endif %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-        ['cython'] if Cython else None,
+        'cython' if Cython else None,
 {% endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
-        ['cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else None,
+        'cffi>=1.0.0' if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else None,
 {% endif %}
     ])),
 {%- if cookiecutter.command_line_interface != 'no' %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -169,14 +169,14 @@ setup(
     tests_require=['{{cookiecutter.test_runner}}'],
     setup_requires=(
         []
-{% if cookiecutter.test_runner == 'pytest' %}
+{%- if cookiecutter.test_runner == 'pytest' %}
         + ['pytest-runner']
 {% endif %}
-{% if cookiecutter.c_extension_support == 'cython' %}
-        + ['cython'] if Cython else []
+{%- if cookiecutter.c_extension_support == 'cython' %}
+        + (['cython'] if Cython else [])
 {% endif %}
-{% if cookiecutter.c_extension_support == 'cffi' %}
-        + ['cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else []
+{%- if cookiecutter.c_extension_support == 'cffi' %}
+        + (['cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [])
 {% endif %}
     ),
 {%- if cookiecutter.command_line_interface != 'no' %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -167,11 +167,18 @@ setup(
         #   ':python_version=="2.6"': ['argparse'],
     },
     tests_require=['{{cookiecutter.test_runner}}'],
-{%- if cookiecutter.c_extension_support == 'cython' %}
-    setup_requires=[
-        'cython',
-    ] if Cython else [],
-{%- endif %}
+    setup_requires=(
+        []
+{% if cookiecutter.test_runner == 'pytest' %}
+        + ['pytest-runner']
+{% endif %}
+{% if cookiecutter.c_extension_support == 'cython' %}
+        + ['cython'] if Cython else []
+{% endif %}
+{% if cookiecutter.c_extension_support == 'cffi' %}
+        + ['cffi>=1.0.0'] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else []
+{% endif %}
+    ),
 {%- if cookiecutter.command_line_interface != 'no' %}
     entry_points={
         'console_scripts': [
@@ -184,9 +191,6 @@ setup(
     cmdclass={'build_ext': optional_build_ext},
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
-    setup_requires=[
-        'cffi>=1.0.0',
-    ] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [],
     cffi_modules=[i + ':ffi' for i in glob('src/*/_*_build.py')],
 {%- else %}
     ext_modules=[

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -176,7 +176,7 @@ setup(
     setup_requires = [{{setup_requires_from_test_runner}}
         'cython',
     ] if Cython else [{{setup_requires_from_test_runner}}
-    ]
+    ],
 {%- elif cookiecutter.c_extension_support == 'cffi' %}
     setup_requires = [{{setup_requires_from_test_runner}}
         'cffi>=1.0.0',


### PR DESCRIPTION
This is sort of a feature request: This changes setup.py and setup.cfg so that in a newly-created package, by default, python setup.py test will run whatever test runner was selected.

This required collapsing multiple settings of `setup_requires` in setup.py so that we could include the necessary pytest-runner and still include cffi and cython in `setup_requires` when needed. (I can split of that collapsing as a separate branch if that would be clearer.)

The best way I could think of to allow the jinja2 if-blocks to either add or not add to `setup_requires` was to use list concatenation.