### PR TITLE
Run installable tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,12 @@ You will be asked for these fields:
       - Whether to use the test_runner for python setup.py test.
         Note that this will also add to ``setup_requires`` if a test-runner is needed.
 
+    * - ``run_tests_that_are_installed_with_package``
+      - .. code:: python
+
+            "pytest"
+      - Run tests in the source directory (that is, tests installed with the package).
+
     * - ``linter``
       - .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -225,10 +225,10 @@ You will be asked for these fields:
       - Whether to use the test_runner for python setup.py test.
         Note that this will also add to ``setup_requires`` if a test-runner is needed.
 
-    * - ``tests_installed_with_package_also_run``
+    * - ``allow_tests_inside_package``
       - .. code:: python
 
-            "pytest"
+            "no"
       - Run tests in the source directory (that is, tests installed with the package).
 
     * - ``linter``

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ You will be asked for these fields:
       - Whether to use the test_runner for python setup.py test.
         Note that this will also add to ``setup_requires`` if a test-runner is needed.
 
-    * - ``run_tests_that_are_installed_with_package``
+    * - ``tests_installed_with_package_also_run``
       - .. code:: python
 
             "pytest"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -42,6 +42,7 @@
     "test_matrix_separate_coverage": ["no", "yes"],
     "test_runner": ["pytest", "nose"],
     "test_runner_used_for_setuppy_test": ["no", "yes"],
+    "run_tests_that_are_installed_with_package": ["no", "yes"],
     "linter": ["flake8", "pylama"],
     "command_line_interface": ["plain", "argparse", "click", "no"],
     "command_line_interface_bin_name": "{{ cookiecutter.distribution_name }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -42,7 +42,7 @@
     "test_matrix_separate_coverage": ["no", "yes"],
     "test_runner": ["pytest", "nose"],
     "test_runner_used_for_setuppy_test": ["no", "yes"],
-    "tests_installed_with_package_also_run": ["no", "yes"],
+    "allow_tests_inside_package": ["no", "yes"],
     "linter": ["flake8", "pylama"],
     "command_line_interface": ["plain", "argparse", "click", "no"],
     "command_line_interface_bin_name": "{{ cookiecutter.distribution_name }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -42,7 +42,7 @@
     "test_matrix_separate_coverage": ["no", "yes"],
     "test_runner": ["pytest", "nose"],
     "test_runner_used_for_setuppy_test": ["no", "yes"],
-    "run_tests_that_are_installed_with_package": ["no", "yes"],
+    "tests_installed_with_package_also_run": ["no", "yes"],
     "linter": ["flake8", "pylama"],
     "command_line_interface": ["plain", "argparse", "click", "no"],
     "command_line_interface_bin_name": "{{ cookiecutter.distribution_name }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -41,6 +41,9 @@ if __name__ == "__main__":
 {%- if cookiecutter.test_matrix_configurator == 'no' %}
     os.unlink(join('ci', 'templates', 'tox.ini'))
 {% endif %}
+{%- if cookiecutter.tests_installed_with_package_also_run == 'no' %}
+    shutil.rmtree(join('src', '{{ cookiecutter.package_name }}', 'tests'))
+{% endif %}
 
 {%- if cookiecutter.c_extension_support == 'no' %}
     os.unlink(join('src', '{{ cookiecutter.package_name }}', '{{ cookiecutter.c_extension_module }}.c'))

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 {%- if cookiecutter.test_matrix_configurator == 'no' %}
     os.unlink(join('ci', 'templates', 'tox.ini'))
 {% endif %}
-{%- if cookiecutter.tests_installed_with_package_also_run == 'no' %}
+{%- if cookiecutter.allow_tests_inside_package == 'no' %}
     shutil.rmtree(join('src', '{{ cookiecutter.package_name }}', 'tests'))
 {% endif %}
 

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -52,7 +52,6 @@ norecursedirs =
     build
     migrations
 {% else %}
-testpaths = tests
 norecursedirs =
     migrations
 {% endif %}
@@ -72,6 +71,30 @@ addopts =
     --doctest-modules
     --doctest-glob=\*.rst
     --tb=short
+{%- if cookiecutter.run_tests_that_are_installed_with_package == 'yes' %}
+    --pyargs
+testpaths =
+    {{cookiecutter.package_name}}
+    tests/
+# The order of these options matters. testpaths comes after addopts so that
+# {{cookiecutter.package_name}} in testpaths is interpreted as
+# --pyargs {{cookiecutter.package_name}}.
+# Any tests in the src/ directory (that is, tests installed with the package)
+# can be run by any user with pytest --pyargs {{cookiecutter.package_name}}.
+# Packages that are sensitive to the host machine, most famously NumPy,
+# include tests with the installed package so that any user can check
+# at any time that everything is working properly.
+# If you do choose to make installable tests, this will run the installed
+# tests as they are actually installed (same principle as when we ensure that
+# we always test the installed version of the package).
+# If you have no need for this (and your src/ directory is very large),
+# you can save a few milliseconds on testing by telling pytest not to search
+# the src/ directory by removing
+# --pyargs and {{cookiecutter.package_name}} from the options here.
+{%- else %}
+testpaths =
+    tests
+{%- endif %}
 
 {% elif cookiecutter.test_runner == "nose" -%}
 [nosetests]

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -71,7 +71,7 @@ addopts =
     --doctest-modules
     --doctest-glob=\*.rst
     --tb=short
-{%- if cookiecutter.run_tests_that_are_installed_with_package == 'yes' %}
+{%- if cookiecutter.tests_installed_with_package_also_run == 'yes' %}
     --pyargs
 testpaths =
     {{cookiecutter.package_name}}

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -71,7 +71,7 @@ addopts =
     --doctest-modules
     --doctest-glob=\*.rst
     --tb=short
-{%- if cookiecutter.tests_installed_with_package_also_run == 'yes' %}
+{%- if cookiecutter.allow_tests_inside_package == 'yes' %}
     --pyargs
 testpaths =
     {{cookiecutter.package_name}}


### PR DESCRIPTION
Minor suggestion for pytest default settings --- going for least astonishment, someone who puts a `test_*` file in `src/` (that is, a test to be installed with the package) probably will not be surprised or confused if `pytest` finds and runs those tests.