### PR TITLE
Allow non-readthedocs documentation hosting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -323,6 +323,12 @@ You will be asked for these fields:
             "no"
       - Add a CodeClimate_ badge in ``README.rst``.
 
+    * - ``sphinx_docs``
+      - .. code:: python
+
+            "yes"
+      - Have Sphinx documentation.
+
     * - ``sphinx_theme``
       - .. code:: python
 
@@ -342,14 +348,13 @@ You will be asked for these fields:
 
         Read more about `doctest support in Sphinx <http://www.sphinx-doc.org/en/stable/ext/doctest.html>`_.
 
-    * - ``documentation_hosting``
+    * - ``sphinx_docs_hosting``
       - .. code:: python
 
             "https://{{ cookiecutter.repo_name|replace('.', '') }}.readthedocs.io/"
       - Leave as default if your documentation will be hosted on readthedocs.
         If your documentation will be hosted elsewhere (such as GitHub Pages or GitLab Pages),
         enter the top-level URL.
-
 
     * - ``travis``
       - .. code:: python

--- a/README.rst
+++ b/README.rst
@@ -342,6 +342,15 @@ You will be asked for these fields:
 
         Read more about `doctest support in Sphinx <http://www.sphinx-doc.org/en/stable/ext/doctest.html>`_.
 
+    * - ``documentation_hosting``
+      - .. code:: python
+
+            "https://{{ cookiecutter.repo_name|replace('.', '') }}.readthedocs.io/"
+      - Leave as default if your documentation will be hosted on readthedocs.
+        If your documentation will be hosted elsewhere (such as GitHub Pages or GitLab Pages),
+        enter the top-level URL.
+
+
     * - ``travis``
       - .. code:: python
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -56,6 +56,7 @@
     "sphinx_docs": ["yes", "no"],
     "sphinx_theme": ["sphinx-rtd-theme", "sphinx-py3doc-enhanced-theme"],
     "sphinx_doctest": ["no", "yes"],
+    "documentation_hosting": "https://{{ cookiecutter.repo_name|replace('.', '') }}.readthedocs.io/",
     "travis": ["yes", "no"],
     "travis_osx": ["no", "yes"],
     "appveyor": ["yes", "no"],

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -56,7 +56,7 @@
     "sphinx_docs": ["yes", "no"],
     "sphinx_theme": ["sphinx-rtd-theme", "sphinx-py3doc-enhanced-theme"],
     "sphinx_doctest": ["no", "yes"],
-    "documentation_hosting": "https://{{ cookiecutter.repo_name|replace('.', '') }}.readthedocs.io/",
+    "sphinx_docs_hosting": "https://{{ cookiecutter.repo_name|replace('.', '') }}.readthedocs.io/",
     "travis": ["yes", "no"],
     "travis_osx": ["no", "yes"],
     "appveyor": ["yes", "no"],

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -117,7 +117,7 @@ Documentation
 =============
 
 {% if cookiecutter.sphinx_docs == "yes" %}
-https://{{ cookiecutter.repo_name|replace('.', '') }}.readthedocs.io/
+{{ cookiecutter.documentation_hosting }}
 {% else %}
 To use the project:
 

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -117,7 +117,7 @@ Documentation
 =============
 
 {% if cookiecutter.sphinx_docs == "yes" %}
-{{ cookiecutter.documentation_hosting }}
+{{ cookiecutter.sphinx_docs_hosting }}
 {% else %}
 To use the project:
 


### PR DESCRIPTION
Currently, out of the box, `tox -e docs` crashes if documentation is not hosted on readthedocs, complaining of a broken link.

The adds a way to enter a custom URL if documentation is hosted in a non-standard location such as GitHub Pages or GitLab Pages.