### PR TITLE
Remove os.unlink(join('ci', 'appveyor-download.py'))

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -91,7 +91,6 @@ if __name__ == "__main__":
 {%- endif %}
 
 {%- if cookiecutter.appveyor == 'no' %}
-    os.unlink(join('ci', 'appveyor-download.py'))
     os.unlink(join('ci', 'appveyor-with-compiler.cmd'))
     os.unlink(join('ci', 'templates', '.appveyor.yml'))
     if os.path.exists('.appveyor.yml'):


### PR DESCRIPTION
https://github.com/ionelmc/cookiecutter-pylibrary/commit/c426c169d0bec5faa5dace5f2c59865595ca77d8 removed appveyor-download.py, but post_gen_project.py still tries to unlink the non-existing file. This causes the generation to crash if cookiecutter.appveyor == 'no'.