### PR TITLE
Run installed tests on CI runner

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -80,7 +80,7 @@ commands =
     nocov: {posargs:pytest -vv --ignore=src}
     cover: {posargs:pytest --cov --cov-report=term-missing -vv}
     {%- else %}
-    {posargs:pytest --cov --cov-report=term-missing -vv {%- if cookiecutter.allow_tests_inside_package == "no" %}tests{% endif %}}
+    {posargs:pytest --cov --cov-report=term-missing -vv {% if cookiecutter.allow_tests_inside_package == "no" %}tests{% endif %}}
     {%- endif %}
 {%- else %}
     {%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -80,7 +80,7 @@ commands =
     nocov: {posargs:pytest -vv --ignore=src}
     cover: {posargs:pytest --cov --cov-report=term-missing -vv}
     {%- else %}
-    {posargs:pytest --cov --cov-report=term-missing -vv tests}
+    {posargs:pytest --cov --cov-report=term-missing -vv {%- if cookiecutter.allow_tests_inside_package == "no" %}tests{% endif %}}
     {%- endif %}
 {%- else %}
     {%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}


### PR DESCRIPTION
This makes it so that the test command does not specify the tests directory.
This only changes things for the case of allow_tests_inside_package, but honestly I think we could just remove the specification of the tests directory regardless, with no jinja2 switch. The config file already specifies where the tests are; if we specify the directory in the command, I'm pretty sure that's actually overriding the config file and making the config file superfluous.