### PR TITLE
.gitlab-ci.yml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,12 @@ You will be asked for these fields:
       - Use ``"no"`` for no hosting (various links will disappear). You can also use ``"gitlab"`` and such but various
         things will be broken (like Travis configuration).
 
+    * - ``ci_https_proxy``
+      - .. code:: python
+
+            null
+      - If your CI runner requires an HTTPS proxy, then you can specify it here.
+
     * - ``repo_name``
       - .. code:: python
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
     "project_name": "Nameless",
     "repo_name": "python-{{ cookiecutter.project_name|lower|replace(' ','-') }}",
     "repo_hosting": ["github", "gitlab", "no"],
+    "ci_https_proxy": null,
     "repo_username": "ionelmc",
     "package_name": "{{ cookiecutter.project_name|lower|replace(' ','_')|replace('-','_') }}",
     "distribution_name": "{{ cookiecutter.package_name|replace('_','-') }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -108,6 +108,10 @@ if __name__ == "__main__":
         os.unlink('.travis.yml')
 {% endif %}
 
+{%- if 'gitlab' not in cookiecutter.repo_hosting %}
+    os.unlink('.gitlab-ci.yml')
+{% endif %}
+
 {%- if cookiecutter.repo_hosting == 'no' %}
     os.unlink('CONTRIBUTING.rst')
 {% endif %}

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   HTTPS_PROXY: {{cookiecutter.ci_https_proxy}}
   # If we don't include NO_PROXY, we will get "fatal unable to update url base from redirection"
   # when trying to fetch the gitlab-ci-token.
-  NO_PROXY: 127.0.0.1,localhost,/var/run/docker.sock,{{cookiecutter.repo_hosting}}
+  NO_PROXY: 127.0.0.1,localhost,.lan,.local,.home,/var/run/docker.sock,{{cookiecutter.repo_hosting}}
 
 pages:
   script:

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+image: alpine
+
+variables:
+  # HTTP_PROXY is used to pull docker images.
+  HTTP_PROXY: {{cookiecutter.ci_https_proxy}}
+  # HTTPS_PROXY is used to install Python packages such as tox.
+  HTTPS_PROXY: {{cookiecutter.ci_https_proxy}}
+  # If we don't include NO_PROXY, we will get "fatal unable to update url base from redirection"
+  # when trying to fetch the gitlab-ci-token.
+  NO_PROXY: 127.0.0.1,localhost,/var/run/docker.sock,{{cookiecutter.repo_hosting}}
+
+pages:
+  script:
+  - apk --no-cache add py2-pip python-dev
+  - pip install tox
+  - tox -e docs
+  - mv dist/docs/ public/
+  artifacts:
+    paths:
+    - public
+  only:
+  - master

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -20,8 +20,8 @@ pages:
   script:
   - apk add python3 git # probably do not want --no-cache
     # check-manifest, used in tox -e check, requires git.
-  - pip3 install tox
   - pip3 install --upgrade pip
+  - pip3 install tox
   - git --version
   - python3 --version
   - virtualenv --version

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -26,7 +26,7 @@ pages:
   - virtualenv --version
   - pip3 --version
   - uname --all
-  - lsb_release --all
+  # Some distributions do not include the standard lsb_release command.
   - tox
   - mv dist/docs/ public/
   artifacts:

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -21,6 +21,12 @@ pages:
   - apk add python3 git # probably do not want --no-cache
     # check-manifest, used in tox -e check, requires git.
   - pip3 install tox
+  - git --version
+  - python --version
+  - virtualenv --version
+  - pip3 --version
+  - uname --all
+  - lsb_release --all
   - tox
   - mv dist/docs/ public/
   artifacts:

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -22,7 +22,7 @@ pages:
     # check-manifest, used in tox -e check, requires git.
   - pip3 install tox
   - git --version
-  - python --version
+  - python3 --version
   - virtualenv --version
   - pip3 --version
   - uname --all

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -19,6 +19,7 @@ variables:
 pages:
   script:
   - apk add python3 git # probably do not want --no-cache
+    # check-manifest, used in tox -e check, requires git.
   - pip3 install tox
   - tox
   - mv dist/docs/ public/

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -18,9 +18,9 @@ variables:
 
 pages:
   script:
-  - apk --no-cache add py2-pip python-dev
-  - pip install tox
-  - tox -e docs
+  - apk add python3 git # probably do not want --no-cache
+  - pip3 install tox
+  - tox
   - mv dist/docs/ public/
   artifacts:
     paths:

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -21,6 +21,7 @@ pages:
   - apk add python3 git # probably do not want --no-cache
     # check-manifest, used in tox -e check, requires git.
   - pip3 install tox
+  - pip3 install --upgrade pip
   - git --version
   - python3 --version
   - virtualenv --version

--- a/{{cookiecutter.repo_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.repo_name}}/.gitlab-ci.yml
@@ -8,6 +8,13 @@ variables:
   # If we don't include NO_PROXY, we will get "fatal unable to update url base from redirection"
   # when trying to fetch the gitlab-ci-token.
   NO_PROXY: 127.0.0.1,localhost,.lan,.local,.home,/var/run/docker.sock,{{cookiecutter.repo_hosting}}
+  # If some of the links in your documentation require a special PEM to verify,
+  # then sphinx -b linkcheck will fail without that PEM.
+  # But setting REQUESTS_CA_BUNDLE to that PEM will cause other links to fail,
+  # because the runner will only accept that PEM, not the defaults.
+  # Therefore you will usually want to bundle all certificates together with
+  # cat `python -c "import requests; print(requests.certs.where())"` ~/your.pem > ~/bundled.pem
+  # REQUESTS_CA_BUNDLE: ci/name-of-your-ca-bundle.pem
 
 pages:
   script:


### PR DESCRIPTION
This sets up a created repo for GitLab Continuous Integration, if it is hosted on GitLab.
The tests get run, and the generated documentation is put up on GitLab Pages.

This unfortunately adds a new user input `ci_https_proxy` in order to make it all work. On the other hand, there might be ways to use that for other, non-GitLab CI too; I don't know enough about CI to know.