### PR TITLE
Fix the changelog header-length calculation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -52,9 +52,6 @@ if __name__ == "__main__":
 
 
     today = datetime.date.today()
-    replace_contents('CHANGELOG.rst',
-                     'hooks/post_gen_project.py replace this with datetime.date.today().strftime("%Y-%m-%d")',
-                     datetime.date.today().strftime("%Y-%m-%d"))
     replace_contents(join('docs', 'conf.py'), '<YEAR>', today.strftime("%Y"))
     replace_contents('LICENSE', '<YEAR>', today.strftime("%Y"))
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
 
     today = datetime.date.today()
-    replace_contents('CHANGELOG.rst', '<TODAY>', today.strftime("%Y-%m-%d"))
+    replace_contents('CHANGELOG.rst', 'datetime.date.today().strftime("%Y-%m-%d")', datetime.date.today().strftime("%Y-%m-%d"))
     replace_contents(join('docs', 'conf.py'), '<YEAR>', today.strftime("%Y"))
     replace_contents('LICENSE', '<YEAR>', today.strftime("%Y"))
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -52,7 +52,9 @@ if __name__ == "__main__":
 
 
     today = datetime.date.today()
-    replace_contents('CHANGELOG.rst', 'datetime.date.today().strftime("%Y-%m-%d")', datetime.date.today().strftime("%Y-%m-%d"))
+    replace_contents('CHANGELOG.rst',
+                     'hooks/post_gen_project.py replace this with datetime.date.today().strftime("%Y-%m-%d")',
+                     datetime.date.today().strftime("%Y-%m-%d"))
     replace_contents(join('docs', 'conf.py'), '<YEAR>', today.strftime("%Y"))
     replace_contents('LICENSE', '<YEAR>', today.strftime("%Y"))
 

--- a/{{cookiecutter.repo_name}}/CHANGELOG.rst
+++ b/{{cookiecutter.repo_name}}/CHANGELOG.rst
@@ -1,7 +1,7 @@
 
 Changelog
 =========
-{% set datestring = 'datetime.date.today().strftime("%Y-%m-%d")' if cookiecutter.release_date == 'today' else cookiecutter.release_date %}
+{% set datestring = 'hooks/post_gen_project.py replace this with datetime.date.today().strftime("%Y-%m-%d")' if cookiecutter.release_date == 'today' else cookiecutter.release_date %}
 {{ cookiecutter.version }} ({{ datestring }})
 {% for _ in cookiecutter.version %}-{% endfor %}--{{ '-' * (4+1+2+1+2 if cookiecutter.release_date == 'today' else datestring|length) }}-
 

--- a/{{cookiecutter.repo_name}}/CHANGELOG.rst
+++ b/{{cookiecutter.repo_name}}/CHANGELOG.rst
@@ -3,6 +3,6 @@ Changelog
 =========
 {% set datestring = 'datetime.date.today().strftime("%Y-%m-%d")' if cookiecutter.release_date == 'today' else cookiecutter.release_date %}
 {{ cookiecutter.version }} ({{ datestring }})
-{% for _ in cookiecutter.version %}-{% endfor %}--{{ '-' * (4+1+2+1+2 if cookiecutter.release_date == 'today' else len(datestring)) }}-
+{% for _ in cookiecutter.version %}-{% endfor %}--{{ '-' * (4+1+2+1+2 if cookiecutter.release_date == 'today' else datestring|length) }}-
 
 * First release on PyPI.

--- a/{{cookiecutter.repo_name}}/CHANGELOG.rst
+++ b/{{cookiecutter.repo_name}}/CHANGELOG.rst
@@ -1,8 +1,12 @@
 
 Changelog
 =========
-{% set datestring = 'hooks/post_gen_project.py replace this with datetime.date.today().strftime("%Y-%m-%d")' if cookiecutter.release_date == 'today' else cookiecutter.release_date %}
+{% set datestring -%}
+{% if cookiecutter.release_date == 'today' -%}
+{% now 'utc', '%Y-%m-%d' %}
+{%- else %}{{ cookiecutter.release_date }}{% endif %}
+{%- endset %}
 {{ cookiecutter.version }} ({{ datestring }})
-{% for _ in cookiecutter.version %}-{% endfor %}--{{ '-' * (4+1+2+1+2 if cookiecutter.release_date == 'today' else datestring|length) }}-
+{% for _ in cookiecutter.version %}-{% endfor %}--{{ '-' * (datestring|length) }}-
 
 * First release on PyPI.

--- a/{{cookiecutter.repo_name}}/CHANGELOG.rst
+++ b/{{cookiecutter.repo_name}}/CHANGELOG.rst
@@ -1,8 +1,8 @@
 
 Changelog
 =========
-{% set datestring = '<TODAY>' if cookiecutter.release_date == 'today' else cookiecutter.release_date %}
+{% set datestring = 'datetime.date.today().strftime("%Y-%m-%d")' if cookiecutter.release_date == 'today' else cookiecutter.release_date %}
 {{ cookiecutter.version }} ({{ datestring }})
-{% for _ in cookiecutter.version %}-{% endfor %}-{% for _ in datestring %}-{% endfor %}
+{% for _ in cookiecutter.version %}-{% endfor %}--{{ '-' * (4+1+2+1+2 if cookiecutter.release_date == 'today' else len(datestring)) }}-
 
 * First release on PyPI.


### PR DESCRIPTION
to match the length of `datetime.date.today().strftime("%Y-%m-%d")`.

This is hideously ugly, but there seems to be no way to call `datetime.date.today().strftime("%Y-%m-%d")` from jinja2 itself, nor can a cookiecutter pre_gen_project hook change the `cookiecutter.release_date` argument. So the only alternative to get a matching underline would be for the post_gen_project hook that inserts the date also insert an appropriate length of "-". (Which...I guess that would also be an option, if you'd prefer that.)