### PR TITLE
Test python-nameless locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ script:
       git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
     else
       echo Failed to get publish-key
+      tox --sitepackages
     fi
   - echo Done.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,10 @@ script:
       PR=""
     fi
     git diff
+  # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
     git reset --hard
     bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
+  # set +x ensures the values of the secret variables are not printed in cleartext.
     set +x
   - |
     if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in publish-key.enc -out ~/.ssh/publish-key -d; then
@@ -69,7 +71,6 @@ script:
       git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
     else
       echo Failed to get publish-key
-      tox --sitepackages
     fi
   - echo Done.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,14 +58,13 @@ script:
       PR=""
     fi
     git diff
-  # set +x ensures the values of the secret variables are not printed in cleartext.
     set +x
   - |
     if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in publish-key.enc -out ~/.ssh/publish-key -d; then
       chmod u=rw,og= ~/.ssh/publish-key
       echo "Host github.com" >> ~/.ssh/config
       echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
-  # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
+      # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
       git reset --hard
       bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
       git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,6 @@ script:
       PR=""
     fi
     git diff
-  # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
-    git reset --hard
-    bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
   # set +x ensures the values of the secret variables are not printed in cleartext.
     set +x
   - |
@@ -68,9 +65,13 @@ script:
       chmod u=rw,og= ~/.ssh/publish-key
       echo "Host github.com" >> ~/.ssh/config
       echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
+  # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
+      git reset --hard
+      bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
       git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
     else
       echo Failed to get publish-key
+      tox --sitepackages
     fi
   - echo Done.
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -37,4 +37,4 @@ safe_sed 's/py37-nocov,//' tox.ini
 safe_sed 's/,pypy3}/}/' tox.ini
 safe_sed 's/pypy3-cover,//' tox.ini
 safe_sed 's/pypy3-nocov,//' tox.ini
-tox -l
+tox --sitepackages

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -37,4 +37,3 @@ safe_sed 's/py37-nocov,//' tox.ini
 safe_sed 's/,pypy3}/}/' tox.ini
 safe_sed 's/pypy3-cover,//' tox.ini
 safe_sed 's/pypy3-nocov,//' tox.ini
-tox --sitepackages


### PR DESCRIPTION
…if we cannot push python-nameless for any reason.

Hrm. Looks like maybe Travis has PyPy 3.2.4? I'm not sure.
```
pypy3-cover create: /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3-cover

ERROR: invocation failed (exit code 1), logfile: /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3-cover/log/pypy3-cover-0.log

================================== log start ===================================

Running virtualenv with interpreter /opt/python/pypy3-2.4.0/bin/pypy3

New pypy executable in /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3-cover/bin/pypy3

Also creating executable in /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3-cover/bin/pypy

Installing setuptools, pip, wheel...

  Complete output from command /home/travis/build/i...ypy3-cover/bin/pypy3 - setuptools pip wheel:

  Traceback (most recent call last):

  File "<stdin>", line 8, in <module>

zipimport.ZipImportError: Python 3.3 or later is required

During handling of the above exception, another exception occurred:

Traceback (most recent call last):

  File "<stdin>", line 11, in <module>

ImportError: cannot import name 'main'

----------------------------------------

...Installing setuptools, pip, wheel...done.

Traceback (most recent call last):

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/virtualenv.py", line 2343, in <module>

    main()

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/virtualenv.py", line 712, in main

    symlink=options.symlink)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/virtualenv.py", line 947, in create_environment

    download=download,

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/virtualenv.py", line 904, in install_wheel

    call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/virtualenv.py", line 796, in call_subprocess

    % (cmd_desc, proc.returncode))

OSError: Command /home/travis/build/i...ypy3-cover/bin/pypy3 - setuptools pip wheel failed with error code 1
```