### PR TITLE
Remove pypy3 regardless of which side the comma is on.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -32,9 +32,9 @@ bumpversion major
 safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
 safe_sed 's/,py37,/,/' tox.ini
 safe_sed 's/py37,//' tox.ini
+safe_sed 's/pypy3,//' tox.ini
 safe_sed 's/py37-cover,//' tox.ini
 safe_sed 's/py37-nocov,//' tox.ini
 safe_sed 's/,pypy3}/}/' tox.ini
-safe_sed 's/pypy3,}/}/' tox.ini
 safe_sed 's/pypy3-cover,//' tox.ini
 safe_sed 's/pypy3-nocov,//' tox.ini

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,5 +35,6 @@ safe_sed 's/py37,//' tox.ini
 safe_sed 's/py37-cover,//' tox.ini
 safe_sed 's/py37-nocov,//' tox.ini
 safe_sed 's/,pypy3}/}/' tox.ini
+safe_sed 's/pypy3,}/}/' tox.ini
 safe_sed 's/pypy3-cover,//' tox.ini
 safe_sed 's/pypy3-nocov,//' tox.ini


### PR DESCRIPTION
This makes ENV=matrix-cext pass on Travis.

Note that three builds are still failing on Travis, but those failures are not caused by this change --- see #146 and #147.