### PR TITLE
Define block setup_requires_interior

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = [
+    "setuptools>=30.3.0",
+    "wheel",
+{%- if cookiecutter.test_runner == 'pytest' and cookiecutter.setup_py_uses_test_runner == 'yes' %}
+    "pytest-runner",
+{%- endif %}
+{%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' %}
+    "setuptools_scm>=3.3.1",
+{%- endif %}
+{%- if cookiecutter.c_extension_support == 'cython' %}
+    "cython",
+{%- elif cookiecutter.c_extension_support == 'cffi' %}
+    "cffi>=1.0.0",
+{%- endif %}
+]

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -37,6 +37,10 @@ max_line_length = 140
 #
 # Unless you're in one of those situations, you can simply ignore this.
 tests_require = {{ cookiecutter.test_runner }}
+
+[aliases]
+# Alias `setup.py test` to `setup.py {{ cookiecutter.test_runner }}`
+test = {{ cookiecutter.test_runner }}
 {% endif %}
 {% if cookiecutter.test_runner == "pytest" -%}
 
@@ -75,9 +79,6 @@ addopts =
     --tb=short
 {%- if cookiecutter.allow_tests_inside_package == 'yes' %}
     --pyargs
-testpaths =
-    {{cookiecutter.package_name}}
-    tests/
 # The order of these options matters. testpaths comes after addopts so that
 # {{cookiecutter.package_name}} in testpaths is interpreted as
 # --pyargs {{cookiecutter.package_name}}.
@@ -93,6 +94,9 @@ testpaths =
 # you can save a few milliseconds on testing by telling pytest not to search
 # the src/ directory by removing
 # --pyargs and {{cookiecutter.package_name}} from the options here.
+testpaths =
+    {{cookiecutter.package_name}}
+    tests/
 {%- else %}
 testpaths =
     tests
@@ -101,12 +105,6 @@ testpaths =
 {% elif cookiecutter.test_runner == "nose" -%}
 [nosetests]
 verbosity = 2
-
-{% endif -%}
-{% if cookiecutter.setup_py_uses_test_runner == 'yes' -%}
-[aliases]
-# Alias `setup.py test` to `setup.py {{ cookiecutter.test_runner }}`
-test = {{ cookiecutter.test_runner }}
 
 {% endif -%}
 [tool:isort]

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -15,15 +15,9 @@ skip = */migrations/*
 [pylama:pycodestyle]
 max_line_length = 140
 {%- endif %}
-{%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' or cookiecutter.setup_py_uses_test_runner == 'yes' %}
+{%- if cookiecutter.setup_py_uses_test_runner == 'yes' %}
 
 [options]
-{%- endif %}
-{%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' %}
-setup_requires =
-  setuptools_scm>=3.3.1
-{% endif %}
-{%- if cookiecutter.setup_py_uses_test_runner == 'yes' %}
 # tests_require is a list of dependencies that are *absolutely required*
 # to run the tests. tests_require is used when running tests from your
 # *current* Python environment (that is, not using tox).

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -186,7 +186,7 @@ setup(
 {%- if cookiecutter.test_runner == 'pytest' and cookiecutter.setup_py_uses_test_runner == 'yes' %}
         'pytest-runner',{% endif %}
 {%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' %}
-        'setuptools_scm',{% endif %}
+        'setuptools_scm>=3.3.1',{% endif %}
 {%- endset %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
     setup_requires=[{{ setup_requires_interior }}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -194,6 +194,9 @@ setup(
     ] if Cython else [{{ setup_requires_interior }}
     ],
 {%- elif cookiecutter.c_extension_support == 'cffi' %}
+    # We only require CFFI when compiling.
+    # pyproject.toml does not support requirements only for some build actions,
+    # but we can do it in setup.py.
     setup_requires=[{{ setup_requires_interior }}
         'cffi>=1.0.0',
     ] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [{{setup_requires_interior}}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -182,24 +182,24 @@ setup(
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],
     },
-{%- if cookiecutter.test_runner == 'pytest' and cookiecutter.setup_py_uses_test_runner == 'yes' -%}
-{% set setup_requires_from_test_runner %}
-        'pytest-runner',{% endset %}
-{%- else -%}
-{% set setup_requires_from_test_runner %}{% endset %}
-{%- endif -%}
+{% set setup_requires_interior -%}
+{%- if cookiecutter.test_runner == 'pytest' and cookiecutter.setup_py_uses_test_runner == 'yes' %}
+        'pytest-runner',{% endif %}
+{%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' %}
+        'setuptools_scm',{% endif %}
+{%- endset %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-    setup_requires=[{{ setup_requires_from_test_runner }}
+    setup_requires=[{{ setup_requires_interior }}
         'cython',
-    ] if Cython else [{{ setup_requires_from_test_runner }}
+    ] if Cython else [{{ setup_requires_interior }}
     ],
 {%- elif cookiecutter.c_extension_support == 'cffi' %}
-    setup_requires=[{{ setup_requires_from_test_runner }}
+    setup_requires=[{{ setup_requires_interior }}
         'cffi>=1.0.0',
-    ] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [{{setup_requires_from_test_runner}}
+    ] if any(i.startswith('build') or i.startswith('bdist') for i in sys.argv) else [{{setup_requires_interior}}
     ],
 {%- else %}
-    setup_requires=[{{ setup_requires_from_test_runner }}
+    setup_requires=[{{ setup_requires_interior }}
     ],
 {%- endif -%}
 {%- if cookiecutter.command_line_interface != 'no' %}


### PR DESCRIPTION
…that includes both pytest-runner and setuptools_scm as appropriate.

Resolves #147.

Note that this still has two Travis failures on ENV=pure-private (due to #146) and ENV=matrix-cext (that will be fixed by #145).