### PR TITLE
Run doctests on all python versions

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -39,6 +39,9 @@ deps =
     coverage
     {%- endif %}
 {%- endif %}
+{%- if cookiecutter.sphinx_doctest == "yes" %}
+    sphinx
+{%- endif %}
 commands =
 {%- if cookiecutter.c_extension_support != "no" %}
     python setup.py clean --all build_ext --force --inplace
@@ -55,6 +58,9 @@ commands =
     {%- else %}
     {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name}} tests}
     {%- endif %}
+{%- endif %}
+{%- if cookiecutter.sphinx_doctest == "yes" %}
+    sphinx-build {posargs:-E} -b doctest docs dist/docs
 {%- endif %}
 
 [testenv:bootstrap]
@@ -130,9 +136,6 @@ install_command =
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
-{%- if cookiecutter.sphinx_doctest == "yes" %}
-    sphinx-build {posargs:-E} -b doctest docs dist/docs
-{%- endif %}
     sphinx-build {posargs:-E} -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -69,6 +69,9 @@ deps =
     nose
     {% if cookiecutter.test_matrix_separate_coverage == 'yes' %}cover: {% endif %}coverage
 {%- endif %}
+{%- if cookiecutter.sphinx_doctest == "yes" %}
+    sphinx
+{%- endif %}
 commands =
 {%- if cookiecutter.c_extension_support != "no" %}
     {%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}
@@ -89,6 +92,9 @@ commands =
     {%- else %}
     {posargs:nosetests --with-coverage --cover-package={{ cookiecutter.package_name}} tests}
     {%- endif %}
+{%- endif %}
+{%- if cookiecutter.sphinx_doctest == "yes" %}
+    sphinx-build {posargs:-E} -b doctest docs dist/docs
 {%- endif %}
 
 [testenv:check]
@@ -143,9 +149,6 @@ install_command =
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
-{%- if cookiecutter.sphinx_doctest == "yes" %}
-    sphinx-build {posargs:-E} -b doctest docs dist/docs
-{%- endif %}
     sphinx-build {posargs:-E} -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
 {%- endif %}


### PR DESCRIPTION
It seems like if we have doctests, they are part of the test suite and should probably be run with all Python versions used to run the rest of the test suite.