### PR TITLE
removed twine register command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -484,7 +484,6 @@ And then you can build the ``sdist``, and if possible, the ``bdist_wheel`` too::
 
 To make a release of the project on PyPI, assuming you got some distributions in ``dist/``, the most simple usage is::
 
-    twine register dist/*
     twine upload --skip-existing dist/*.whl dist/*.gz dist/*.zip
 
 In ZSH you can use this to upload everything in ``dist/`` that ain't a linux-specific wheel (you may need ``setopt extended_glob``)::


### PR DESCRIPTION
`twine register` is no longer required or supported for PyPI.

```
HTTPError: 410 Client Error: Project pre-registration is no longer required or supported, upload your files instead. for url: https://upload.pypi.org/legacy/
```

I could upload just by doing:
```
twine upload --skip-existing dist/*.whl dist/*.gz
```

## changes
* removed `twine register` from `README`

(i just noticed it was already reported as issue)
Solves #104 