### PR TITLE
config env:spell according to doctest

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -115,7 +115,11 @@ setenv =
     SPELLCHECK=1
 commands =
     sphinx-build -b spelling docs dist/docs
+{%- if cookiecutter.sphinx_doctest == "yes" %}
+usedevelop = true
+{%- else %}
 skip_install = true
+{%- endif %}
 deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-spelling

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -128,7 +128,11 @@ setenv =
     SPELLCHECK=1
 commands =
     sphinx-build -b spelling docs dist/docs
+{%- if cookiecutter.sphinx_doctest == "yes" %}
+usedevelop = true
+{%- else %}
 skip_install = true
+{%- endif %}
 deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-spelling


### PR DESCRIPTION
As far my understanding goes, selection `doctest` during the setup introduces `.. testsetup::` in the `reference/sampleproject.rst` file.

This creates incompatibilities with the `env:spell` in tox because the option `skip_install` is activated:

```
WARNING: autodoc: failed to import module 'sampleproject'; the following exception was raised:
No module named 'sampleproject'
```

In `doctest` is selected, `usedevelop` should be used instead of `skip_install`.

I have added this option in the `tox.ini` templates.
This issue directly relates with #159 

Let me know your opinion and if more additions/changes in the code are required to complete the implementation.