### PR TITLE
Just to try this crazy idea to have tox install Cython for testenv:pypy.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -32,7 +32,7 @@ bumpversion major
 safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
 safe_sed 's/,py37,/,/' tox.ini
 safe_sed 's/py37,//' tox.ini
-safe_sed 's/pypy3,//' tox.ini
+safe_sed 's/pypy,pypy3,//' tox.ini
 safe_sed 's/py37-cover,//' tox.ini
 safe_sed 's/py37-nocov,//' tox.ini
 safe_sed 's/,pypy3}/}/' tox.ini

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -32,9 +32,9 @@ bumpversion major
 safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
 safe_sed 's/,py37,/,/' tox.ini
 safe_sed 's/py37,//' tox.ini
-safe_sed 's/pypy,pypy3,//' tox.ini
+safe_sed 's/pypy3,//' tox.ini
 safe_sed 's/py37-cover,//' tox.ini
 safe_sed 's/py37-nocov,//' tox.ini
-safe_sed 's/,pypy3}/}/' tox.ini
+safe_sed 's/pypy,pypy3}/}/' tox.ini
 safe_sed 's/pypy3-cover,//' tox.ini
 safe_sed 's/pypy3-nocov,//' tox.ini

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,6 +35,6 @@ safe_sed 's/py37,//' tox.ini
 safe_sed 's/pypy3,//' tox.ini
 safe_sed 's/py37-cover,//' tox.ini
 safe_sed 's/py37-nocov,//' tox.ini
-safe_sed 's/pypy,pypy3}/}/' tox.ini
+safe_sed 's/,pypy,pypy3}/}/' tox.ini
 safe_sed 's/pypy3-cover,//' tox.ini
 safe_sed 's/pypy3-nocov,//' tox.ini

--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -39,6 +39,9 @@ deps =
     coverage
     {%- endif %}
 {%- endif %}
+{%- if cookiecutter.c_extension_support == 'cython' %}
+    pypy: Cython
+{%- endif %}
 commands =
 {%- if cookiecutter.c_extension_support != "no" %}
     python setup.py clean --all build_ext --force --inplace

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -11,6 +11,6 @@ requires = [
 {%- if cookiecutter.c_extension_support == 'cython' %}
     "Cython",
 {%- elif cookiecutter.c_extension_support == 'cffi' %}
-    "cffi>=1.0.0",
+    "cffi>=1.0.0; platform_python_implementation != 'PyPy'",
 {%- endif %}
 ]

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "setuptools_scm>=3.3.1",
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-    "cython",
+    "Cython",
 {%- elif cookiecutter.c_extension_support == 'cffi' %}
     "cffi>=1.0.0",
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -195,7 +195,7 @@ setup(
 {%- endset %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
     setup_requires=[{{ setup_requires_interior }}
-        'cython',
+        'Cython',
     ] if Cython else [{{ setup_requires_interior }}
     ],
 {%- elif cookiecutter.c_extension_support == 'cffi' %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -70,7 +70,7 @@ deps =
     {% if cookiecutter.test_matrix_separate_coverage == 'yes' %}cover: {% endif %}coverage
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cython' %}
-    pypy: cython
+    pypy: Cython
 {%- endif %}
 commands =
 {%- if cookiecutter.c_extension_support != "no" %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -69,6 +69,9 @@ deps =
     nose
     {% if cookiecutter.test_matrix_separate_coverage == 'yes' %}cover: {% endif %}coverage
 {%- endif %}
+{%- if cookiecutter.c_extension_support == 'cython' %}
+    pypy: cython
+{%- endif %}
 commands =
 {%- if cookiecutter.c_extension_support != "no" %}
     {%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}


### PR DESCRIPTION
Resolves #161. Maybe.

Okay, this is...weird.
```
ERROR: invocation failed (exit code 1), logfile: /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy/log/pypy-2.log
================================== log start ===================================
Looking in links: file:///home/travis/.pip/wheels
Processing ./.tox/.tmp/package/1/nameless-1.0.0.zip
  Could not find a version that satisfies the requirement cython (from versions: )
```
But `setup_requires` didn't ask for cython. It asked for Cython. The requirement cython must be coming from *somewhere else*.

We could probably `from _setuputils import PYPY` in setup.py, but really the requirement is coming from pyproject.toml.
https://gemfury.com/squarecapadmin/python:gevent/-/content/setup.py

Strangely, even with "cffi>=1.0.0; platform_python_implementation != 'PyPy'", it still tries to install cffi>=1.0.0 and still complains of not finding it.