### PR TITLE
Remove automodule when running spellcheck.

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -112,7 +112,12 @@ commands =
 
 [testenv:spell]
 setenv =
-    SPELLCHECK=1
+    RUNNING_TOX_TESTENV_SPELLCHECK=1
+    # We use an environment variable here because Sphinx -D will not accept arbitrary settings.
+    # https://www.sphinx-doc.org/en/master/man/sphinx-build.html#id2
+    # sphinx-build just emits
+    # WARNING: unknown config value 'RUNNING_TOX_TESTENV_SPELLCHECK' in override, ignoring
+    # https://github.com/sphinx-doc/sphinx/issues/2795
 commands =
     sphinx-build -b spelling docs dist/docs
 skip_install = true

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -19,14 +19,9 @@ if os.getenv('RUNNING_TOX_TESTENV_SPELLCHECK'):
     extensions += 'sphinxcontrib.spelling',
     # If RUNNING_TOX_TESTENV_SPELLCHECK, then we do not want to run autodoc,
     # because there is no need to spellcheck the autodocs.
-    # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx-core-events
-    def source_read_handler(app, docname, source):
-        for i,s in enumerate(source):
-            source[i] = s.replace('''.. automodule:: {{ cookiecutter.package_name }}
-    :members:''', '')
-    def setup(app):
-        app.connect('source-read', source_read_handler)
-    # alternate way to transform: https://github.com/sympy/sphinx-math-dollar/blob/master/sphinx_math_dollar/extension.py
+    # testenv:spell skips installing the module, so all that remains is to
+    # silence the warning when .. automodule:: {{ cookiecutter.package_name }} fails to import.
+    suppress_warnings = ['autodoc.import_object']
     spelling_show_suggestions = True
     spelling_lang = 'en_US'
 

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -5,7 +5,7 @@ import os
 
 
 extensions = [
-    'sphinx.ext.autodoc',
+    # Either autosummary or napoleon implies 'sphinx.ext.autodoc'.
     'sphinx.ext.autosummary',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
@@ -15,8 +15,18 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
 ]
-if os.getenv('SPELLCHECK'):
+if os.getenv('RUNNING_TOX_TESTENV_SPELLCHECK'):
     extensions += 'sphinxcontrib.spelling',
+    # If RUNNING_TOX_TESTENV_SPELLCHECK, then we do not want to run autodoc,
+    # because there is no need to spellcheck the autodocs.
+    # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx-core-events
+    def source_read_handler(app, docname, source):
+        for i,s in enumerate(source):
+            source[i] = s.replace('''.. automodule:: {{ cookiecutter.package_name }}
+    :members:''', '')
+    def setup(app):
+        app.connect('source-read', source_read_handler)
+    # alternate way to transform: https://github.com/sympy/sphinx-math-dollar/blob/master/sphinx_math_dollar/extension.py
     spelling_show_suggestions = True
     spelling_lang = 'en_US'
 

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -125,7 +125,12 @@ commands =
 
 [testenv:spell]
 setenv =
-    SPELLCHECK=1
+    RUNNING_TOX_TESTENV_SPELLCHECK=1
+    # We use an environment variable here because Sphinx -D will not accept arbitrary settings.
+    # https://www.sphinx-doc.org/en/master/man/sphinx-build.html#id2
+    # sphinx-build just emits
+    # WARNING: unknown config value 'RUNNING_TOX_TESTENV_SPELLCHECK' in override, ignoring
+    # https://github.com/sphinx-doc/sphinx/issues/2795
 commands =
     sphinx-build -b spelling docs dist/docs
 skip_install = true


### PR DESCRIPTION
Also changes the name of the environment variable so it'll be easier to see where it comes from next time someone looks at this code.

This is another way to silence that
```
WARNING: autodoc: failed to import module 'sampleproject'; the following exception was raised:
No module named 'sampleproject'
```

It is not necessary to do anything with the `testsetup` that imports the module, because unlike autodoc, doctest already automatically doesn't do anything if you don't ask for it; the `testsetup` becomes inert and therefore no import occurs.