### PR TITLE
Remove the spell env

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,7 +48,7 @@ To set up `cookiecutter-pylibrary` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
+4. When you're done making changes run all the checks and docs builder with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
 
     tox
 

--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ To set up `{{ cookiecutter.repo_name }}` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
+4. When you're done making changes run all the checks and docs builder with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
 
     tox
 

--- a/{{cookiecutter.repo_name}}/ci/templates/tox.ini
+++ b/{{cookiecutter.repo_name}}/ci/templates/tox.ini
@@ -16,7 +16,7 @@ wheel = true
 {%- endif %}
 basepython =
 {%- if cookiecutter.sphinx_docs == "yes" %}
-    {docs,spell}: {env:TOXPYTHON:python3.6}
+    docs: {env:TOXPYTHON:python3.6}
 {%- endif %}
     {bootstrap,clean,check,report{%- if cookiecutter.codecov == 'yes' %},codecov{% endif %}{% if cookiecutter.coveralls == 'yes' %},coveralls{% if cookiecutter.c_extension_support != "no" %},extension-coveralls{% endif %}{% endif %}}: {env:TOXPYTHON:python3}
 setenv =
@@ -109,17 +109,6 @@ commands =
     {posargs:python setup.py clean --all build_ext --force}
 {%- endif %}
 {% if cookiecutter.sphinx_docs == "yes" %}
-
-[testenv:spell]
-setenv =
-    SPELLCHECK=1
-commands =
-    sphinx-build -b spelling docs dist/docs
-skip_install = true
-deps =
-    -r{toxinidir}/docs/requirements.txt
-    sphinxcontrib-spelling
-    pyenchant
 
 [testenv:docs]
 usedevelop = true

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -17,11 +17,6 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
 ]
-if os.getenv('SPELLCHECK'):
-    extensions += 'sphinxcontrib.spelling',
-    spelling_show_suggestions = True
-    spelling_lang = 'en_US'
-
 source_suffix = '.rst'
 master_doc = 'index'
 project = {{ '{0!r}'.format(cookiecutter.project_name) }}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -143,7 +143,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -172,7 +171,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[
 {%- if cookiecutter.command_line_interface == 'click' %}
         'click',

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -42,7 +42,7 @@ basepython =
     pypy3: {env:TOXPYTHON:pypy3}
     py27: {env:TOXPYTHON:python2.7}
     py35: {env:TOXPYTHON:python3.5}
-    {% if cookiecutter.sphinx_docs == "yes" %}{py36,docs,spell}{% else %}py36{% endif %}: {env:TOXPYTHON:python3.6}
+    {% if cookiecutter.sphinx_docs == "yes" %}{py36,docs}{% else %}py36{% endif %}: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     {bootstrap,clean,check,report{%- if cookiecutter.codecov == 'yes' %},codecov{% endif %}{% if cookiecutter.coveralls == 'yes' %},coveralls{% if cookiecutter.c_extension_support != "no" %},extension-coveralls{% endif %}{% endif %}}: {env:TOXPYTHON:python3}
@@ -131,17 +131,6 @@ commands =
     {posargs:python setup.py clean --all build_ext --force}
 {%- endif %}
 {%- if cookiecutter.sphinx_docs == "yes" %}
-
-[testenv:spell]
-setenv =
-    SPELLCHECK=1
-commands =
-    sphinx-build -b spelling docs dist/docs
-skip_install = true
-deps =
-    -r{toxinidir}/docs/requirements.txt
-    sphinxcontrib-spelling
-    pyenchant
 
 [testenv:docs]
 usedevelop = true


### PR DESCRIPTION
- it's cumbersome as you have to whitelist almost all programming jargon and names
- it's mostly and useless appendix - doesn't run in CI
- it relies on the unmaintained pyenchant lib

@dHannasch @joaomcteixeira now only thing left is to recommend some alternatives to checking spelling besides pycharm/other-big-IDE.

Closes #163 #160 #159 #12.