### PR TITLE
Add .readthedocs.yml config file to configure Read the Docs build.

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -51,6 +51,11 @@ if __name__ == "__main__":
 
 {% if cookiecutter.sphinx_docs == "no" %}
     shutil.rmtree('docs')
+    os.unlink('.readthedocs.yml')
+{%- else %}
+{%- if 'readthedocs' not in cookiecutter.sphinx_docs_hosting %}
+    os.unlink('.readthedocs.yml')
+{% endif %}
 {% endif %}
 
 {%- if cookiecutter.command_line_interface == 'no' %}

--- a/{{cookiecutter.repo_name}}/.readthedocs.yml
+++ b/{{cookiecutter.repo_name}}/.readthedocs.yml
@@ -1,0 +1,26 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    # Install package using pip for the build (needed for autodoc)
+    - method: pip
+        path: .


### PR DESCRIPTION
Adds a ``.readthedocs.yml`` config file, which configures the Read the Docs build.
In the docs build, the package is installed using pip so the autodoc feature works. 
Since this config file overrides the advanced settings as configured in the UI, the user does not need to activate the virtualenv setting anymore. 

The ``.readthedocs.yml`` is removed if ``cookiecutter.sphinx_docs == "no" `` or if ``"readthedocs" is not in cookiecutter.sphinx_docs_hosting``. 

Implements changes suggested by #176.