### PR TITLE
Fix syntax error in .readthedocs.yml

### DIFF
--- a/{{cookiecutter.repo_name}}/.readthedocs.yml
+++ b/{{cookiecutter.repo_name}}/.readthedocs.yml
@@ -23,4 +23,4 @@ python:
     - requirements: docs/requirements.txt
     # Install package using pip for the build (needed for autodoc)
     - method: pip
-        path: .
+      path: .


### PR DESCRIPTION
Fixes #185 

This indentation changes fixes a Read the Docs yaml parsing failure,
which surfaces as this Error:

Problem in your project's configuration. Parse error in .readthedocs.yml: YAML:
mapping values are not allowed here in "<unicode string>"
line 26, column 13: path: .

See more before-and-after in my r2b2 project: https://github.com/gwexploratoryaudits/r2b2/pull/5

Discussion at https://stackoverflow.com/a/41236822/507544