### PR TITLE
Ignore  Notebook Checkpoints .ipynb_checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ docs/_build
 .build
 .ve
 .bootstrap
+
+# Notebook Checkpoints
+.ipynb_checkpoints/
+
 # Cookiecutter
 output/
 boilerplate/


### PR DESCRIPTION
IPython / Jupyter Notebook checkpoints should be ignored.

Following example at https://github.com/ipython/ipynb/blob/master/.gitignore