### PR TITLE
added spaces inbetween "python -m" and package_name templates

### DIFF
--- a/{{cookiecutter.repo_name}}/ci/templates/.appveyor.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.appveyor.yml
@@ -60,9 +60,9 @@ init:
   - ps: ls C:\Python*
 install:
 {%- if cookiecutter.c_extension_test_pypi == "yes" %}
-  - '%PYTHON_HOME%\python -mpip install --progress-bar=off twine tox-wheel -rci/requirements.txt'
+  - '%PYTHON_HOME%\python -m pip install --progress-bar=off twine tox-wheel -rci/requirements.txt'
 {%- else %}
-  - '%PYTHON_HOME%\python -mpip install --progress-bar=off tox -rci/requirements.txt'
+  - '%PYTHON_HOME%\python -m pip install --progress-bar=off tox -rci/requirements.txt'
 {%- endif %}
   - '%PYTHON_HOME%\Scripts\virtualenv --version'
   - '%PYTHON_HOME%\Scripts\easy_install --version'

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -86,9 +86,9 @@ before_install:
 {%- endif %}
 install:
 {%- if cookiecutter.c_extension_test_pypi == "yes" %}
-  - python -mpip install --progress-bar=off twine tox-wheel -rci/requirements.txt
+  - python -m pip install --progress-bar=off twine tox-wheel -rci/requirements.txt
 {%- else %}
-  - python -mpip install --progress-bar=off tox -rci/requirements.txt
+  - python -m pip install --progress-bar=off tox -rci/requirements.txt
 {%- endif %}
   - virtualenv --version
   - easy_install --version

--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/__main__.py
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/__main__.py
@@ -1,5 +1,5 @@
 """
-Entrypoint module, in case you use `python -m{{cookiecutter.package_name}}`.
+Entrypoint module, in case you use `python -m {{cookiecutter.package_name}}`.
 
 
 Why does this file exist, and why __main__? For more info, read:

--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/cli.py
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/cli.py
@@ -6,7 +6,7 @@ Why does this file exist, and why not put this in __main__?
   You might be tempted to import things from __main__ later, but that will cause
   problems: the code will get executed twice:
 
-  - When you run `python -m{{cookiecutter.package_name}}` python will execute
+  - When you run `python -m {{cookiecutter.package_name}}` python will execute
     ``__main__.py`` as a script. That means there won't be any
     ``{{cookiecutter.package_name}}.__main__`` in ``sys.modules``.
   - When you import __main__ it will get executed again (as a module) because


### PR DESCRIPTION
I found two instances of `python -m<package>` in docstrings generated by this cookiecutter template. Note that there's no space inbetween `-m` and `<package>`! I have thus modified the corresponding template files to indeed add a space inbetween.

```
originally: python -m{{cookiecutter.package_name}}
       now: python -m {{cookiecutter.package_name}}
```

tox passed, and when using this modified cookiecutter template I did indeed see the desired whitespace :) Hope that's ok, please tell me if I'm missing something. <sup>This project has been super useful to me, so many thanks to ionelmc and all who've contributed~</sup>

