### PR TITLE
If _cffi_backend 1.5.2 is installed, upgrade to 1.14.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
 install:
   - mkdir -p ~/.pip
   - cp ci/pip.conf ~/.pip/pip.conf
+  - if dpkg --status python-cffi; then apt-get install --upgrade python-cffi; fi
   - pip install -U wheel setuptools tox cookiecutter bumpversion
   - virtualenv --version
   - tox --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 install:
   - mkdir -p ~/.pip
   - cp ci/pip.conf ~/.pip/pip.conf
-  - if dpkg --status python-cffi; then apt-get install --upgrade python-cffi; fi
+  - if dpkg --status python-cffi; then apt-get upgrade python-cffi; fi
   - pip install -U wheel setuptools tox cookiecutter bumpversion
   - virtualenv --version
   - tox --version

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools_scm>=3.3.1",
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
-    'cffi>=1.0.0,<1.6; python_version<="2"',
-    'cffi>=1.0.0; python_version>"2"',
+    'cffi>=1.0.0,<1.6; python_version<"3"',
+    'cffi>=1.0.0; python_version>="3"',
 {%- endif %}
 ]

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     "setuptools_scm>=3.3.1",
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
-    "cffi>=1.0.0",
+    'cffi>=1.0.0,<1.6; python_version<="2"',
+    'cffi>=1.0.0; python_version>"2"',
 {%- endif %}
 ]

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -206,7 +206,8 @@ setup(
         'click',
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
-        'cffi>=1.0.0',
+        'cffi>=1.0.0,<1.6; python_version<="2"',
+        'cffi>=1.0.0; python_version>"2"',
 {%- endif %}
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
     ],

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -206,6 +206,7 @@ setup(
         'click',
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
+        # Does this have any effect? seems like pyproject.toml is what matters
         'cffi>=1.0.0,<1.6; python_version<="2"',
         'cffi>=1.0.0; python_version>"2"',
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -207,8 +207,8 @@ setup(
 {%- endif %}
 {%- if cookiecutter.c_extension_support == 'cffi' %}
         # Does this have any effect? seems like pyproject.toml is what matters
-        'cffi>=1.0.0,<1.6; python_version<="2"',
-        'cffi>=1.0.0; python_version>"2"',
+        'cffi>=1.0.0,<1.6; python_version<"3"',
+        'cffi>=1.0.0; python_version>="3"',
 {%- endif %}
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
     ],


### PR DESCRIPTION
Fixes
```
    Exception: Version mismatch: this is the 'cffi' package version 1.14.1, located in '/tmp/pip-build-env-IrZ1TX/overlay/lib/python2.7/site-packages/cffi/api.pyc'.  When we import the top-level '_cffi_backend' extension module, we get version 1.5.2, located in '/usr/lib/python2.7/dist-packages/_cffi_backend.x86_64-linux-gnu.so'.  The two versions should be equal; check your installation.
```
on Travis and thus resolves https://github.com/ionelmc/cookiecutter-pylibrary/issues/203.

(Of course the build still fails due to https://github.com/ionelmc/cookiecutter-pylibrary/issues/206, but this fixes the version mismatch crash.)