### PR TITLE
Fix PyPy BackendUnavailable crash on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 dist: xenial
-python: '3.8'
+python:
+- '3.8'
+- 'pypy'
+- 'pypy3'
 cache: pip
 env:
   global:

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=30.3.0",
+    "setuptools>=40.8.0",
     "wheel",
 {%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' %}
     "setuptools_scm>=3.3.1",
@@ -9,3 +9,4 @@ requires = [
     "cffi>=1.0.0",
 {%- endif %}
 ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This does not fix the BackendUnavailable error after all.
```
pypy3 create: /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3
pypy3 installdeps: pytest, pytest-travis-fold, pytest-cov
pypy3 inst: /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/.tmp/package/1/nameless-1.0.0.zip
ERROR: invocation failed (exit code 2), logfile: /home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/log/pypy3-2.log
================================== log start ===================================
Looking in links: file:///home/travis/.pip/wheels
Processing ./.tox/.tmp/package/1/nameless-1.0.0.zip
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
ERROR: Exception:
Traceback (most recent call last):
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/cli/base_command.py", line 188, in main
    status = self.run(options, args)
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/commands/install.py", line 345, in run
    resolver.resolve(requirement_set)
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/legacy_resolve.py", line 196, in resolve
    self._resolve_one(requirement_set, req)
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/legacy_resolve.py", line 359, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/legacy_resolve.py", line 307, in _get_abstract_dist_for
    self.require_hashes
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/operations/prepare.py", line 215, in prepare_linked_requirement
    finder, self.build_isolation,
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_internal/distributions/source.py", line 70, in prepare_distribution_metadata
    reqs = self.req.pep517_backend.get_requires_for_build_wheel()
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_vendor/pep517/wrappers.py", line 71, in get_requires_for_build_wheel
    'config_settings': config_settings
  File "/home/travis/build/ionelmc/cookiecutter-pylibrary/python-nameless/.tox/pypy3/site-packages/pip/_vendor/pep517/wrappers.py", line 162, in _call_hook
    raise BackendUnavailable
pip._vendor.pep517.wrappers.BackendUnavailable
```

It looks like the error is actually related to https://github.com/pypa/setuptools/issues/1644, maybe.

It looks like a nontrivial pyproject.toml might simply not work with PyPy: https://github.com/pypa/pep517/issues/74