### PR TITLE
Make isort pass if cookiecutter.setup_py_uses_setuptools_scm is no

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -4,14 +4,13 @@ from __future__ import unicode_literals
 {% if cookiecutter.sphinx_theme == 'sphinx-rtd-theme' -%}
 import os
 {% endif -%}
-{% if cookiecutter.setup_py_uses_setuptools_scm == 'yes' -%}
+{%- if cookiecutter.setup_py_uses_setuptools_scm == 'yes' -%}
 import traceback
 {% endif -%}
 {%- if cookiecutter.sphinx_theme != 'sphinx-rtd-theme' %}
 
 import {{ cookiecutter.sphinx_theme|replace('-', '_') }}
-{%- endif %}
-
+{% endif %}
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -6,7 +6,7 @@ import os
 {% endif -%}
 {% if cookiecutter.setup_py_uses_setuptools_scm == 'yes' -%}
 import traceback
-{%- endif %}
+{% endif -%}
 {%- if cookiecutter.sphinx_theme != 'sphinx-rtd-theme' %}
 
 import {{ cookiecutter.sphinx_theme|replace('-', '_') }}


### PR DESCRIPTION
Shift deletion of whitespace so that isort does not complain if cookiecutter.setup_py_uses_setuptools_scm is no and thus `import trackback` is left out of conf.py.

This PR works (see https://gitlab.com/dHannasch/python-nameless/-/pipelines), though of course the Travis builds are still failing for unrelated reasons.