### PR TITLE
Simpler fix for the cffi version mismatch and backend problems

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ install:
   - ps: Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "c:\\get-pip.py"
   - "c:\\python27\\python c:\\get-pip.py setuptools"
   - "c:\\python27\\Scripts\\pip wheel tox virtualenv cookiecutter bumpversion"
-  - "c:\\python27\\Scripts\\pip wheel pytest-capturelog pytest-cov pytest"
+  - "c:\\python27\\Scripts\\pip wheel pytest-cov pytest"
   - "c:\\python27\\Scripts\\pip wheel nose coverage"
   - "c:\\python27\\Scripts\\pip wheel cpp-coveralls"
   - "c:\\python27\\Scripts\\pip wheel jinja2 matrix"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: bionic
+dist: xenial
 python: '3.8'
 cache: pip
 env:
@@ -58,25 +58,25 @@ script:
     fi
     set +x
   - |
-    if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
-      chmod u=rw,og= ~/.ssh/publish-key
-      echo "Host github.com" >> ~/.ssh/config
-      echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
-      # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
-      git reset --hard
-      bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
-      git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
-    else
+    #if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
+    #  chmod u=rw,og= ~/.ssh/publish-key
+    #  echo "Host github.com" >> ~/.ssh/config
+    #  echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
+    #  # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
+    #  git reset --hard
+    #  bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
+    #  git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
+    #else
       echo Failed to get publish-key
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
-        curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/$name.tar.bz2
+        curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/$name.tar.bz2
         sudo tar xjf $name.tar.bz2 --directory /
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
       tox --sitepackages
-    fi
+    #fi
   - echo Done.
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,25 +58,25 @@ script:
     fi
     set +x
   - |
-    if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
-      chmod u=rw,og= ~/.ssh/publish-key
-      echo "Host github.com" >> ~/.ssh/config
-      echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
-      # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
-      git reset --hard
-      bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
-      git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
-    else
+      # if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
+      #   chmod u=rw,og= ~/.ssh/publish-key
+      #   echo "Host github.com" >> ~/.ssh/config
+      #   echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
+      #   # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
+      #   git reset --hard
+      #   bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
+      #   git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
+      # else
       echo Failed to get publish-key
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
-        curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/$name.tar.bz2
+        curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/$name.tar.bz2
         tar xjf $name.tar.bz2 --directory /
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
       tox --sitepackages
-    fi
+      # fi
   - echo Done.
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 install:
   - mkdir -p ~/.pip
   - cp ci/pip.conf ~/.pip/pip.conf
-  - pip install -U wheel setuptools tox cookiecutter bumpversion
+  - pip install --upgrade --ignore-installed wheel setuptools tox cookiecutter bumpversion cffi
   - virtualenv --version
   - tox --version
 script:
@@ -67,6 +67,7 @@ script:
     #  bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
     #  git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
     #else
+      set -x
       echo Failed to get publish-key
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
         curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/$name.tar.bz2
-        tar xjf $name.tar.bz2 --directory /
+        sudo tar xjf $name.tar.bz2 --directory /
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 python: '3.8'
 cache: pip
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 dist: xenial
+virt: lxd
 python: '3.8'
 cache: pip
-virt: lxd
 env:
   global:
     - LD_PRELOAD=libSegFault.so
@@ -59,7 +59,7 @@ script:
     fi
     set +x
   - |
-    if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
+    if [ "$TRAVIS_BRANCH" -eq "master" ] && openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
       chmod u=rw,og= ~/.ssh/publish-key
       echo "Host github.com" >> ~/.ssh/config
       echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,15 +58,15 @@ script:
     fi
     set +x
   - |
-      # if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
-      #   chmod u=rw,og= ~/.ssh/publish-key
-      #   echo "Host github.com" >> ~/.ssh/config
-      #   echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
-      #   # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
-      #   git reset --hard
-      #   bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
-      #   git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
-      # else
+    if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
+      chmod u=rw,og= ~/.ssh/publish-key
+      echo "Host github.com" >> ~/.ssh/config
+      echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
+      # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
+      git reset --hard
+      bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
+      git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
+    else
       echo Failed to get publish-key
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
@@ -76,7 +76,7 @@ script:
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
       tox --sitepackages
-      # fi
+    fi
   - echo Done.
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,17 +59,17 @@ script:
     fi
     set +x
   - |
-    #if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
-    #  chmod u=rw,og= ~/.ssh/publish-key
-    #  echo "Host github.com" >> ~/.ssh/config
-    #  echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
-    #  # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
-    #  git reset --hard
-    #  bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
-    #  git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
-    #else
+    if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
+      chmod u=rw,og= ~/.ssh/publish-key
+      echo "Host github.com" >> ~/.ssh/config
+      echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
+      # ci/test.sh mangles tox.ini a bit for testing, so we need to undo that.
+      git reset --hard
+      bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
+      git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
+    else
+      echo Failed to get publish-key, running tests locally...
       set -x
-      echo Failed to get publish-key
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
         curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/$name.tar.bz2
@@ -77,8 +77,9 @@ script:
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
+      set +x
       tox
-    #fi
+    fi
   - echo Done.
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: xenial
 python: '3.8'
 cache: pip
+virt: lxd
 env:
   global:
     - LD_PRELOAD=libSegFault.so
@@ -72,7 +73,7 @@ script:
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
         curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/$name.tar.bz2
-        sudo tar xjf $name.tar.bz2 --directory /
+        tar xjf $name.tar.bz2 --directory /
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
-      tox --sitepackages
+      tox
     #fi
   - echo Done.
 

--- a/ci/templates/.appveyor.yml
+++ b/ci/templates/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - ps: Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "c:\\get-pip.py"
   - "c:\\python27\\python c:\\get-pip.py setuptools"
   - "c:\\python27\\Scripts\\pip wheel tox virtualenv cookiecutter bumpversion"
-  - "c:\\python27\\Scripts\\pip wheel pytest-capturelog pytest-cov pytest"
+  - "c:\\python27\\Scripts\\pip wheel pytest-cov pytest"
   - "c:\\python27\\Scripts\\pip wheel nose coverage"
   - "c:\\python27\\Scripts\\pip wheel cpp-coveralls"
   - "c:\\python27\\Scripts\\pip wheel jinja2 matrix"

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: xenial
 python: '3.8'
 cache: pip
+virt: lxd
 env:
   global:
     - LD_PRELOAD=libSegFault.so
@@ -19,7 +20,7 @@ before_install:
 install:
   - mkdir -p ~/.pip
   - cp ci/pip.conf ~/.pip/pip.conf
-  - pip install -U wheel setuptools tox cookiecutter bumpversion
+  - pip install --upgrade --ignore-installed wheel setuptools tox cookiecutter bumpversion cffi
   - virtualenv --version
   - tox --version
 script:
@@ -47,7 +48,8 @@ script:
       bumpversion --new-version=1.$TRAVIS_JOB_NUMBER minor
       git push git@github.com:ionelmc/python-nameless.git -f HEAD:${PR}test-$ENV
     else
-      echo Failed to get publish-key
+      echo Failed to get publish-key, running tests locally...
+      set -x
       mkdir -p ~/.local/bin
       for name in pypy pypy3; do
         curl -sSf -o $name.tar.bz2 https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/$name.tar.bz2
@@ -55,7 +57,8 @@ script:
         rm $name.tar.bz2
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
-      tox --sitepackages
+      set +x
+      tox
     fi
   - echo Done.
 

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -39,7 +39,7 @@ script:
     fi
     set +x
   - |
-    if openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
+    if [ "$TRAVIS_BRANCH" -eq "master" ] && openssl aes-256-cbc -K $encrypted_a70d5afca909_key -iv $encrypted_a70d5afca909_iv -in ../publish-key.enc -out ~/.ssh/publish-key -d; then
       chmod u=rw,og= ~/.ssh/publish-key
       echo "Host github.com" >> ~/.ssh/config
       echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 dist: xenial
+virt: lxd
 python: '3.8'
 cache: pip
-virt: lxd
 env:
   global:
     - LD_PRELOAD=libSegFault.so

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 python: '3.8'
 cache: pip
 env:

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: bionic
+dist: xenial
 python: '3.8'
 cache: pip
 env:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -30,7 +30,7 @@ bumpversion patch
 bumpversion minor
 bumpversion major
 safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
-for name in py35 py36 py37; do
+for name in py35 py36 py37 py39; do
   for env in $name ${name}-cover ${name}-nocov; do
     safe_sed "s/,$env,/,/" tox.ini
     safe_sed "s/$env,/,/" tox.ini

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 cache: false
 env:
   global:

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 {{ "{%- for env in tox_environments %}{{ '' }}" }}
 {%- endif %}
 {%- if cookiecutter.travis_osx == "yes" %}
-{{ "{%- if 'py38' in env or 'py27' in env %}{{ '' }}" }}
+{{ "{%- if 'py39' in env or 'py27' in env %}{{ '' }}" }}
 {{ "    - os: osx" }}
 {{ "      osx_image: xcode11" }}
 {{ "      language: generic" }}

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 dist: xenial
+virt: lxd
 cache: false
 env:
   global:

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: bionic
+dist: xenial
 cache: false
 env:
   global:

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -142,6 +142,7 @@ python_versions =
     py36
     py37
     py38
+    py39
     pypy
     pypy3
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -175,6 +175,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -29,7 +29,7 @@ envlist =
 {%- if cookiecutter.sphinx_docs == "yes" %}
     docs,
 {%- endif %}
-    {py27,py35,py36,py37,py38,pypy,pypy3}{% if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3}{% if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
     report
 ignore_basepython_conflict = true
 
@@ -45,6 +45,7 @@ basepython =
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
+    py39: {env:TOXPYTHON:python3.9}
     {bootstrap,clean,check,report
         {%- if cookiecutter.sphinx_docs == "yes" -%}
             ,docs


### PR DESCRIPTION
So it turns out that I enabled system site packges (for speed) and that caused problems when building the pip517 wheels (since pip doesn't account for that options it reinstalls cffi and you get the version mismatch). The unavailablebackend issue is gone too (not sure what actually caused it but I suspect it's a hidden cffi mismatch error).

I've switched the virtualization to lxd to get fast builds again.

Passing builds with publishing disabled here:
https://travis-ci.org/github/ionelmc/cookiecutter-pylibrary/builds/740417786
https://travis-ci.org/github/ionelmc/cookiecutter-pylibrary/builds/740360626

Closes #206. Closes #203. Closes #202. Closes #204. Closes #207. Closes #208.