### PR TITLE
Use --sitepackages to accelerate when we can.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,16 @@ script:
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
       set +x
-      tox
+      # Counting the lines in pyproject.toml is a very crude way of determining whether we'll need proper build isolation for
+      # a PEP517 build, but hopefully by the time this could come back to haunt us,
+      # https://github.com/pypa/pip/issues/6264 will be fixed so it won't matter anymore.
+      if [ $(wc --lines < pyproject.toml) -gt 5 ]; then
+        echo "pyproject.toml has $(wc --lines < pyproject.toml) lines, so it is probably nontrivial."
+        tox
+      else
+        echo "As long as pyproject.toml is trivial, it is safe to use system site packages even before pypa/pip#6264 is fixed."
+        tox --sitepackages
+      fi
     fi
   - echo Done.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,12 @@ script:
         ln -s /opt/python/$name/bin/$name ~/.local/bin/$name
       done
       set +x
-      # Counting the lines in pyproject.toml is a very crude way of determining whether we'll need proper build isolation for
-      # a PEP517 build, but hopefully by the time this could come back to haunt us,
-      # https://github.com/pypa/pip/issues/6264 will be fixed so it won't matter anymore.
-      if [ $(wc --lines < pyproject.toml) -gt 5 ]; then
-        echo "pyproject.toml has $(wc --lines < pyproject.toml) lines, so it is probably nontrivial."
+      # This is clunky, but hopefully soon https://github.com/pypa/pip/issues/6264 will be fixed so it won't matter anymore.
+      if [ -e pyproject.toml ]; then
+        echo "We have a PEP517 pyproject.toml, and the Travis PyPy installation has an old setuptools, so we cannot allow system site packages as long as pip has the build isolation bug."
         tox
       else
-        echo "As long as pyproject.toml is trivial, it is safe to use system site packages even before pypa/pip#6264 is fixed."
+        echo "As long as we're not using PEP517, it's safe to use system site packages."
         tox --sitepackages
       fi
     fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -30,9 +30,10 @@ bumpversion patch
 bumpversion minor
 bumpversion major
 safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
-for name in py35 py36 py37; do
+for name in py35 py36 py37 py39; do
   for env in $name ${name}-cover ${name}-nocov; do
     safe_sed "s/,$env,/,/" tox.ini
-    safe_sed "s/$env,/,/" tox.ini
+    safe_sed "s/$env,//" tox.ini
+    safe_sed "s/,$env//" tox.ini
   done
 done


### PR DESCRIPTION
We could actually be even more specific than this, and allow system site packages for every individual testenv except the PyPy ones, or specifying `--no-build-isolation` for PyPy, but I'm not immediately sure how and it likely wouldn't be worth the bother.