### PR TITLE
Issue 214 legacy python2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,10 +7,15 @@ matrix:
 environment:
   matrix:
     - ENV: cext
+    - ENV: cext-nolegacy
     - ENV: cffi
+    - ENV: cffi-nolegacy
     - ENV: cython
+    - ENV: cython-nolegacy
     - ENV: matrix-cext
+    - ENV: matrix-cext-nolegacy
     - ENV: matrix-separate-cext
+    - ENV: matrix-separate-cext-nolegacy
     - ENV: nose-pure
     - ENV: nose-pure-argparse
     - ENV: nose-pure-click
@@ -19,16 +24,21 @@ environment:
     - ENV: pure-argparse
     - ENV: pure-click
     - ENV: pure-nocli
+    - ENV: pure-nolegacy
     - ENV: pure-private
     - ENV: pure-pylama
     - ENV: separate-cext
+    - ENV: separate-cext-nolegacy
     - ENV: separate-cext-scm-osx-publish
     - ENV: separate-cffi
+    - ENV: separate-cffi-nolegacy
     - ENV: separate-cffi-scm-osx-publish
     - ENV: separate-cython
+    - ENV: separate-cython-nolegacy
     - ENV: separate-cython-scm-osx-publish
     - ENV: separate-nose-pure
     - ENV: separate-pure
+    - ENV: separate-pure-nolegacy
 init:
   - "echo %CTX%"
   - "set"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,15 @@ env:
     - SEGFAULT_SIGNALS=all
   matrix:
     - ENV=cext
+    - ENV=cext-nolegacy
     - ENV=cffi
+    - ENV=cffi-nolegacy
     - ENV=cython
+    - ENV=cython-nolegacy
     - ENV=matrix-cext
+    - ENV=matrix-cext-nolegacy
     - ENV=matrix-separate-cext
+    - ENV=matrix-separate-cext-nolegacy
     - ENV=nose-pure
     - ENV=nose-pure-argparse
     - ENV=nose-pure-click
@@ -21,16 +26,21 @@ env:
     - ENV=pure-argparse
     - ENV=pure-click
     - ENV=pure-nocli
+    - ENV=pure-nolegacy
     - ENV=pure-private
     - ENV=pure-pylama
     - ENV=separate-cext
+    - ENV=separate-cext-nolegacy
     - ENV=separate-cext-scm-osx-publish
     - ENV=separate-cffi
+    - ENV=separate-cffi-nolegacy
     - ENV=separate-cffi-scm-osx-publish
     - ENV=separate-cython
+    - ENV=separate-cython-nolegacy
     - ENV=separate-cython-scm-osx-publish
     - ENV=separate-nose-pure
     - ENV=separate-pure
+    - ENV=separate-pure-nolegacy
 before_install:
   - python --version
   - virtualenv --version

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ Features
 This is an "all inclusive" sort of template.
 
 * Choice of various licenses.
-* Tox_ for managing test environments for Python 2.7, 3.3, PyPy etc.
-* Pytest_ or Nose_ for testing Python 2.7, 3.3, PyPy etc.
+* Tox_ for managing test environments for Python 2.7, 3.6+, PyPy etc.
+* Pytest_ or Nose_ for testing Python 2.7, 3.6+, PyPy etc.
 * *Optional* support for creating a tests matrix out of dependencies and python versions.
 * Travis-CI_ and AppVeyor_ for continuous testing.
 * Coveralls_ or Codecov_ for coverage tracking (using Tox_).

--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,13 @@ You will be asked for these fields:
             "0.1.0"
       - Release version (see ``.bumpversion.cfg`` and in Sphinx ``conf.py``).
 
+    * - ``legacy_python``
+      - .. code:: python
+
+            "no"
+      - Allow for legacy python versions, like ``python2.7``. If you do not especially need to support (depreciated) python
+        versions you should keep it as is.
+
     * - ``c_extension_support``
       - .. code:: python
 

--- a/ci/envs/cext-nolegacy.cookiecutterrc
+++ b/ci/envs/cext-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
-  c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_optional: 'no'
+  c_extension_support: 'yes'
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -26,5 +26,5 @@ default_context:
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
   test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/cext.cookiecutterrc
+++ b/ci/envs/cext.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/cffi-nolegacy.cookiecutterrc
+++ b/ci/envs/cffi-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
   c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_support: cffi
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -26,5 +26,5 @@ default_context:
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
   test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/cffi.cookiecutterrc
+++ b/ci/envs/cffi.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/cython-nolegacy.cookiecutterrc
+++ b/ci/envs/cython-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
   c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_support: cython
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -26,5 +26,5 @@ default_context:
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
   test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/cython.cookiecutterrc
+++ b/ci/envs/cython.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/matrix-cext-nolegacy.cookiecutterrc
+++ b/ci/envs/matrix-cext-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
-  c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_optional: 'no'
+  c_extension_support: 'yes'
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -24,7 +24,7 @@ default_context:
   setup_py_uses_setuptools_scm: 'no'
   setup_py_uses_test_runner: 'yes'
   sphinx_docs: 'no'
-  test_matrix_configurator: 'no'
+  test_matrix_configurator: 'yes'
   test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/matrix-cext.cookiecutterrc
+++ b/ci/envs/matrix-cext.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/matrix-separate-cext-nolegacy.cookiecutterrc
+++ b/ci/envs/matrix-separate-cext-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
-  c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_optional: 'no'
+  c_extension_support: 'yes'
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -24,7 +24,7 @@ default_context:
   setup_py_uses_setuptools_scm: 'no'
   setup_py_uses_test_runner: 'yes'
   sphinx_docs: 'no'
-  test_matrix_configurator: 'no'
-  test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_matrix_configurator: 'yes'
+  test_matrix_separate_coverage: 'yes'
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/matrix-separate-cext.cookiecutterrc
+++ b/ci/envs/matrix-separate-cext.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/nose-pure-argparse.cookiecutterrc
+++ b/ci/envs/nose-pure-argparse.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/nose-pure-click.cookiecutterrc
+++ b/ci/envs/nose-pure-click.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/nose-pure.cookiecutterrc
+++ b/ci/envs/nose-pure.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/pure-argparse.cookiecutterrc
+++ b/ci/envs/pure-argparse.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/pure-click.cookiecutterrc
+++ b/ci/envs/pure-click.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/pure-nocli.cookiecutterrc
+++ b/ci/envs/pure-nocli.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/pure-nolegacy.cookiecutterrc
+++ b/ci/envs/pure-nolegacy.cookiecutterrc
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -26,5 +26,5 @@ default_context:
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
   test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/pure-private.cookiecutterrc
+++ b/ci/envs/pure-private.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/pure-pylama.cookiecutterrc
+++ b/ci/envs/pure-pylama.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: pylama
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/pure.cookiecutterrc
+++ b/ci/envs/pure.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-cext-nolegacy.cookiecutterrc
+++ b/ci/envs/separate-cext-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
-  c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_optional: 'no'
+  c_extension_support: 'yes'
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -25,6 +25,6 @@ default_context:
   setup_py_uses_test_runner: 'yes'
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
-  test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_matrix_separate_coverage: 'yes'
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/separate-cext-scm-osx-publish.cookiecutterrc
+++ b/ci/envs/separate-cext-scm-osx-publish.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-cext.cookiecutterrc
+++ b/ci/envs/separate-cext.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-cffi-nolegacy.cookiecutterrc
+++ b/ci/envs/separate-cffi-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
   c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_support: cffi
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -25,6 +25,6 @@ default_context:
   setup_py_uses_test_runner: 'yes'
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
-  test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_matrix_separate_coverage: 'yes'
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/separate-cffi-scm-osx-publish.cookiecutterrc
+++ b/ci/envs/separate-cffi-scm-osx-publish.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-cffi.cookiecutterrc
+++ b/ci/envs/separate-cffi.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-cython-nolegacy.cookiecutterrc
+++ b/ci/envs/separate-cython-nolegacy.cookiecutterrc
@@ -1,6 +1,6 @@
 default_context:
   c_extension_optional: 'yes'
-  c_extension_support: 'no'
+  c_extension_support: cython
   c_extension_test_pypi: 'no'
   c_extension_test_pypi_appveyor_secret: fDwCnDhQiptm9a4ZcFpgyQ==
   c_extension_test_pypi_username: ionel
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -25,6 +25,6 @@ default_context:
   setup_py_uses_test_runner: 'yes'
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
-  test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_matrix_separate_coverage: 'yes'
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/separate-cython-scm-osx-publish.cookiecutterrc
+++ b/ci/envs/separate-cython-scm-osx-publish.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-cython.cookiecutterrc
+++ b/ci/envs/separate-cython.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-nose-pure.cookiecutterrc
+++ b/ci/envs/separate-nose-pure.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/envs/separate-pure-nolegacy.cookiecutterrc
+++ b/ci/envs/separate-pure-nolegacy.cookiecutterrc
@@ -8,12 +8,12 @@ default_context:
   codacy_projectid: 862e7946
   codeclimate: 'yes'
   codecov: 'yes'
-  command_line_interface: nocli
+  command_line_interface: plain
   coveralls: 'yes'
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
-  legacy_python: 'yes'
+  legacy_python: 'no'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"
@@ -25,6 +25,6 @@ default_context:
   setup_py_uses_test_runner: 'yes'
   sphinx_docs: 'no'
   test_matrix_configurator: 'no'
-  test_matrix_separate_coverage: 'no'
-  test_runner: nose
+  test_matrix_separate_coverage: 'yes'
+  test_runner: pytest
   travis_osx: no yes

--- a/ci/envs/separate-pure.cookiecutterrc
+++ b/ci/envs/separate-pure.cookiecutterrc
@@ -13,6 +13,7 @@ default_context:
   coveralls_token: IoRlAEvnKbwbhBJ2jrWPqzAnE2jobA0I3
   full_name: "Ion\"'el Cristian M\u0103rie\u0219"
   landscape: 'yes'
+  legacy_python: 'yes'
   linter: flake8
   package_name: nameless
   project_name: "Nam\xE9\"'less"

--- a/ci/setup.cfg
+++ b/ci/setup.cfg
@@ -7,7 +7,7 @@ test_matrix_separate_coverage =
     : no
 test_runner =
     : pytest
-    nose: nose
+    nose: nose &legacy_python[yes]
 c_extension_support =
     cext: yes &command_line_interface[plain] &test_runner[pytest]
     cython: cython &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no]
@@ -21,23 +21,23 @@ full_name =
 project_name =
     : Namé"'less
 command_line_interface =
-    click
+    click &legacy_python[yes]
     : plain
-    argparse
-    nocli
+    argparse &legacy_python[yes]
+    nocli &legacy_python[yes]
 sphinx_docs =
     : no
 linter =
     : flake8
-    pylama &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[no] &c_extension_support[no] &setup_py_uses_setuptools_scm[no]
+    pylama &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[no] &c_extension_support[no] &setup_py_uses_setuptools_scm[no] &legacy_python[yes]
 setup_py_uses_test_runner =
     : yes
 setup_py_uses_setuptools_scm =
-    scm: yes &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[yes] &c_extension_test_pypi[yes]
+    scm: yes &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[yes] &c_extension_test_pypi[yes] &legacy_python[yes]
     : no
 repo_hosting_domain =
     : github.com
-    private: no &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[no] &c_extension_support[no] &setup_py_uses_setuptools_scm[no] &linter[flake8]
+    private: no &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[no] &c_extension_support[no] &setup_py_uses_setuptools_scm[no] &linter[flake8] &legacy_python[yes]
 travis_osx =
     : no yes &c_extension_test_pypi[no]
     osx: yes &c_extension_test_pypi[yes]
@@ -46,3 +46,6 @@ c_extension_test_pypi =
     publish: yes &command_line_interface[plain] &test_runner[pytest] &test_matrix_configurator[no] &test_matrix_separate_coverage[yes] !c_extension_support[no] &setup_py_uses_setuptools_scm[yes]
 c_extension_test_pypi_username =
     : ionel
+legacy_python =
+    : yes
+    nolegacy: no

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -30,7 +30,7 @@ bumpversion patch
 bumpversion minor
 bumpversion major
 safe_sed 's/sphinx-build -b linkcheck/#/' tox.ini
-for name in py35 py36 py37 py39; do
+for name in py36 py37 py39; do
   for env in $name ${name}-cover ${name}-nocov; do
     safe_sed "s/,$env,/,/" tox.ini
     safe_sed "s/$env,//" tox.ini

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -43,6 +43,7 @@
         "GNU Lesser General Public License v2.1 (LGPLv2)",
         "no"
     ],
+    "legacy_python": ["no", "yes"],
     "c_extension_support": ["no", "yes", "cffi", "cython"],
     "c_extension_optional": ["no", "yes"],
     "c_extension_module": "_{{ cookiecutter.package_name }}",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py36}-{cext,cffi,cython,matrix-cext,matrix-separate-cext,nose-pure,nose-pure-argparse,nose-pure-click,nose-pure-nocli,pure,pure-argparse,pure-click,pure-nocli,pure-private,pure-pylama,separate-cext,separate-cext-scm-osx-publish,separate-cffi,separate-cffi-scm-osx-publish,separate-cython,separate-cython-scm-osx-publish,separate-nose-pure,separate-pure}
+    {py27,py36}-{cext,cext-nolegacy,cffi,cffi-nolegacy,cython,cython-nolegacy,matrix-cext,matrix-cext-nolegacy,matrix-separate-cext,matrix-separate-cext-nolegacy,nose-pure,nose-pure-argparse,nose-pure-click,nose-pure-nocli,pure,pure-argparse,pure-click,pure-nocli,pure-nolegacy,pure-private,pure-pylama,separate-cext,separate-cext-nolegacy,separate-cext-scm-osx-publish,separate-cffi,separate-cffi-nolegacy,separate-cffi-scm-osx-publish,separate-cython,separate-cython-nolegacy,separate-cython-scm-osx-publish,separate-nose-pure,separate-pure,separate-pure-nolegacy}
 skipsdist = true
 
 [testenv]
@@ -20,18 +20,33 @@ deps =
 [testenv:py27-cext]
 commands =
     {toxinidir}/ci/test.cmd cext
+[testenv:py27-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd cext-nolegacy
 [testenv:py27-cffi]
 commands =
     {toxinidir}/ci/test.cmd cffi
+[testenv:py27-cffi-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd cffi-nolegacy
 [testenv:py27-cython]
 commands =
     {toxinidir}/ci/test.cmd cython
+[testenv:py27-cython-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd cython-nolegacy
 [testenv:py27-matrix-cext]
 commands =
     {toxinidir}/ci/test.cmd matrix-cext
+[testenv:py27-matrix-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd matrix-cext-nolegacy
 [testenv:py27-matrix-separate-cext]
 commands =
     {toxinidir}/ci/test.cmd matrix-separate-cext
+[testenv:py27-matrix-separate-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd matrix-separate-cext-nolegacy
 [testenv:py27-nose-pure]
 commands =
     {toxinidir}/ci/test.cmd nose-pure
@@ -56,6 +71,9 @@ commands =
 [testenv:py27-pure-nocli]
 commands =
     {toxinidir}/ci/test.cmd pure-nocli
+[testenv:py27-pure-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd pure-nolegacy
 [testenv:py27-pure-private]
 commands =
     {toxinidir}/ci/test.cmd pure-private
@@ -65,18 +83,27 @@ commands =
 [testenv:py27-separate-cext]
 commands =
     {toxinidir}/ci/test.cmd separate-cext
+[testenv:py27-separate-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-cext-nolegacy
 [testenv:py27-separate-cext-scm-osx-publish]
 commands =
     {toxinidir}/ci/test.cmd separate-cext-scm-osx-publish
 [testenv:py27-separate-cffi]
 commands =
     {toxinidir}/ci/test.cmd separate-cffi
+[testenv:py27-separate-cffi-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-cffi-nolegacy
 [testenv:py27-separate-cffi-scm-osx-publish]
 commands =
     {toxinidir}/ci/test.cmd separate-cffi-scm-osx-publish
 [testenv:py27-separate-cython]
 commands =
     {toxinidir}/ci/test.cmd separate-cython
+[testenv:py27-separate-cython-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-cython-nolegacy
 [testenv:py27-separate-cython-scm-osx-publish]
 commands =
     {toxinidir}/ci/test.cmd separate-cython-scm-osx-publish
@@ -86,21 +113,39 @@ commands =
 [testenv:py27-separate-pure]
 commands =
     {toxinidir}/ci/test.cmd separate-pure
+[testenv:py27-separate-pure-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-pure-nolegacy
 [testenv:py36-cext]
 commands =
     {toxinidir}/ci/test.cmd cext
+[testenv:py36-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd cext-nolegacy
 [testenv:py36-cffi]
 commands =
     {toxinidir}/ci/test.cmd cffi
+[testenv:py36-cffi-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd cffi-nolegacy
 [testenv:py36-cython]
 commands =
     {toxinidir}/ci/test.cmd cython
+[testenv:py36-cython-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd cython-nolegacy
 [testenv:py36-matrix-cext]
 commands =
     {toxinidir}/ci/test.cmd matrix-cext
+[testenv:py36-matrix-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd matrix-cext-nolegacy
 [testenv:py36-matrix-separate-cext]
 commands =
     {toxinidir}/ci/test.cmd matrix-separate-cext
+[testenv:py36-matrix-separate-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd matrix-separate-cext-nolegacy
 [testenv:py36-nose-pure]
 commands =
     {toxinidir}/ci/test.cmd nose-pure
@@ -125,6 +170,9 @@ commands =
 [testenv:py36-pure-nocli]
 commands =
     {toxinidir}/ci/test.cmd pure-nocli
+[testenv:py36-pure-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd pure-nolegacy
 [testenv:py36-pure-private]
 commands =
     {toxinidir}/ci/test.cmd pure-private
@@ -134,18 +182,27 @@ commands =
 [testenv:py36-separate-cext]
 commands =
     {toxinidir}/ci/test.cmd separate-cext
+[testenv:py36-separate-cext-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-cext-nolegacy
 [testenv:py36-separate-cext-scm-osx-publish]
 commands =
     {toxinidir}/ci/test.cmd separate-cext-scm-osx-publish
 [testenv:py36-separate-cffi]
 commands =
     {toxinidir}/ci/test.cmd separate-cffi
+[testenv:py36-separate-cffi-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-cffi-nolegacy
 [testenv:py36-separate-cffi-scm-osx-publish]
 commands =
     {toxinidir}/ci/test.cmd separate-cffi-scm-osx-publish
 [testenv:py36-separate-cython]
 commands =
     {toxinidir}/ci/test.cmd separate-cython
+[testenv:py36-separate-cython-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-cython-nolegacy
 [testenv:py36-separate-cython-scm-osx-publish]
 commands =
     {toxinidir}/ci/test.cmd separate-cython-scm-osx-publish
@@ -155,3 +212,6 @@ commands =
 [testenv:py36-separate-pure]
 commands =
     {toxinidir}/ci/test.cmd separate-pure
+[testenv:py36-separate-pure-nolegacy]
+commands =
+    {toxinidir}/ci/test.cmd separate-pure-nolegacy

--- a/{{cookiecutter.repo_name}}/ci/bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/bootstrap.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+{%- if cookiecutter.legacy_python == "yes" %}
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+{%- endif %}
 
 import os
 import subprocess

--- a/{{cookiecutter.repo_name}}/ci/bootstrap.py
+++ b/{{cookiecutter.repo_name}}/ci/bootstrap.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-{%- if cookiecutter.legacy_python == "yes" %}
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
-{%- endif %}
 
 import os
 import subprocess

--- a/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.repo_name}}/ci/templates/.travis.yml
@@ -80,7 +80,9 @@ before_install:
   - |
     if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       [[ $TOXENV =~ py3 ]] && brew upgrade python
+{%- if cookiecutter.legacy_python == "yes" %}
       [[ $TOXENV =~ py2 ]] && brew install python@2
+{%- endif %}
       export PATH="/usr/local/opt/python/libexec/bin:${PATH}"
     fi
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -139,8 +139,8 @@ skip = .tox,.eggs,ci/templates,build,dist
 python_versions =
 {%- if cookiecutter.legacy_python == "yes" %}
     py27
-{%- endif %}
     py35
+{%- endif %}
     py36
     py37
     py38

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -137,13 +137,17 @@ skip = .tox,.eggs,ci/templates,build,dist
 #  - can use as many you want
 
 python_versions =
+{%- if cookiecutter.legacy_python == "yes" %}
     py27
+{%- endif %}
     py35
     py36
     py37
     py38
     py39
+{%- if cookiecutter.legacy_python == "yes" %}
     pypy
+{%- endif %}
     pypy3
 
 dependencies =

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -139,7 +139,6 @@ skip = .tox,.eggs,ci/templates,build,dist
 python_versions =
 {%- if cookiecutter.legacy_python == "yes" %}
     py27
-    py35
 {%- endif %}
     py36
     py37

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -178,9 +178,6 @@ setup(
 {%- if cookiecutter.legacy_python == "no" %}
         'Programming Language :: Python :: 3 :: Only',
 {%- endif %}
-{%- if cookiecutter.legacy_python == "yes" %}
-        'Programming Language :: Python :: 3.5',
-{%- endif %}
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -211,7 +208,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
 {%- if cookiecutter.legacy_python == "yes" %}
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
 {%- else %}
     python_requires='>=3.6',
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+{%- if cookiecutter.legacy_python == "yes" %}
 from __future__ import absolute_import
 from __future__ import print_function
+{%- endif %}
 
 import io
 {%- if cookiecutter.c_extension_support in ['yes', 'cython'] %}
@@ -169,7 +171,9 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
+{%- if cookiecutter.legacy_python == "yes" %}
         'Programming Language :: Python :: 2.7',
+{%- endif %}
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -201,7 +205,11 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
+{%- if cookiecutter.legacy_python == "yes" %}
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+{%- else %}
+    python_requires='>=3.5',
+{%- endif %}
     install_requires=[
 {%- if cookiecutter.command_line_interface == 'click' %}
         'click',

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -176,7 +176,7 @@ setup(
 {%- endif %}
         'Programming Language :: Python :: 3',
 {%- if cookiecutter.legacy_python == "no" %}
-        # 'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3 :: Only',
 {%- endif %}
 {%- if cookiecutter.legacy_python == "yes" %}
         'Programming Language :: Python :: 3.5',

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -175,7 +175,12 @@ setup(
         'Programming Language :: Python :: 2.7',
 {%- endif %}
         'Programming Language :: Python :: 3',
+{%- if cookiecutter.legacy_python == "no" %}
+        # 'Programming Language :: Python :: 3 :: Only',
+{%- endif %}
+{%- if cookiecutter.legacy_python == "yes" %}
         'Programming Language :: Python :: 3.5',
+{%- endif %}
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -208,7 +213,7 @@ setup(
 {%- if cookiecutter.legacy_python == "yes" %}
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
 {%- else %}
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 {%- endif %}
     install_requires=[
 {%- if cookiecutter.command_line_interface == 'click' %}

--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/{{cookiecutter.c_extension_module}}.c
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/{{cookiecutter.c_extension_module}}.c
@@ -16,7 +16,7 @@ char* {{ cookiecutter.c_extension_function }}(int argc, char *argv[]) {
         return NULL;
     }
 }
-{% else %}
+{% else -%}
 #include "Python.h"
 
 static PyObject* {{ cookiecutter.c_extension_function }}(PyObject *self, PyObject *value) {
@@ -27,16 +27,15 @@ static PyObject* {{ cookiecutter.c_extension_function }}(PyObject *self, PyObjec
     PyObject *args;
     PyObject *kwargs;
     PyObject *result;
-
-{%- if cookiecutter.legacy_python == "yes" %}
-    #if PY_MAJOR_VERSION < 3
-      module = PyImport_ImportModule("__builtin__");
-    #else
+{% if cookiecutter.legacy_python == "yes" %}
+#if PY_MAJOR_VERSION < 3
+    module = PyImport_ImportModule("__builtin__");
+#else
 {%- endif %}
-      module = PyImport_ImportModule("builtins");
+    module = PyImport_ImportModule("builtins");
 {%- if cookiecutter.legacy_python == "yes" %}
-    #endif
-{%- endif %}
+#endif
+{% endif %}
     if (!module)
         return NULL;
 
@@ -103,11 +102,11 @@ static struct PyModuleDef moduledef = {
 static PyObject* moduleinit(void) {
     PyObject *module;
 
-{%- if cookiecutter.legacy_python == "yes" %}
+{% if cookiecutter.legacy_python == "yes" -%}
 #if PY_MAJOR_VERSION >= 3
 {%- endif %}
     module = PyModule_Create(&moduledef);
-{%- if cookiecutter.legacy_python == "yes" %}
+{% if cookiecutter.legacy_python == "yes" -%}
 #else
     module = Py_InitModule3("{{ cookiecutter.package_name }}.{{ cookiecutter.c_extension_module }}", module_functions, NULL);
 #endif
@@ -119,13 +118,13 @@ static PyObject* moduleinit(void) {
     return module;
 }
 
-{%- if cookiecutter.legacy_python == "yes" %}
+{% if cookiecutter.legacy_python == "yes" -%}
 #if PY_MAJOR_VERSION < 3
 PyMODINIT_FUNC init{{ cookiecutter.c_extension_module }}(void) {
     moduleinit();
 }
 #else
-{%- endif %}
+{% endif -%}
 PyMODINIT_FUNC PyInit_{{ cookiecutter.c_extension_module }}(void) {
     return moduleinit();
 }

--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/{{cookiecutter.c_extension_module}}.c
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/{{cookiecutter.c_extension_module}}.c
@@ -28,11 +28,15 @@ static PyObject* {{ cookiecutter.c_extension_function }}(PyObject *self, PyObjec
     PyObject *kwargs;
     PyObject *result;
 
+{%- if cookiecutter.legacy_python == "yes" %}
     #if PY_MAJOR_VERSION < 3
       module = PyImport_ImportModule("__builtin__");
     #else
+{%- endif %}
       module = PyImport_ImportModule("builtins");
+{%- if cookiecutter.legacy_python == "yes" %}
     #endif
+{%- endif %}
     if (!module)
         return NULL;
 
@@ -78,7 +82,9 @@ static struct PyMethodDef module_functions[] = {
     {NULL, NULL}
 };
 
+{%- if cookiecutter.legacy_python == "yes" %}
 #if PY_MAJOR_VERSION >= 3
+{%- endif %}
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "{{ cookiecutter.package_name }}.{{ cookiecutter.c_extension_module }}", /* m_name */
@@ -90,16 +96,22 @@ static struct PyModuleDef moduledef = {
     NULL,             /* m_clear */
     NULL,             /* m_free */
 };
+{%- if cookiecutter.legacy_python == "yes" %}
 #endif
+{%- endif %}
 
 static PyObject* moduleinit(void) {
     PyObject *module;
 
+{%- if cookiecutter.legacy_python == "yes" %}
 #if PY_MAJOR_VERSION >= 3
+{%- endif %}
     module = PyModule_Create(&moduledef);
+{%- if cookiecutter.legacy_python == "yes" %}
 #else
     module = Py_InitModule3("{{ cookiecutter.package_name }}.{{ cookiecutter.c_extension_module }}", module_functions, NULL);
 #endif
+{%- endif %}
 
     if (module == NULL)
         return NULL;
@@ -107,13 +119,17 @@ static PyObject* moduleinit(void) {
     return module;
 }
 
+{%- if cookiecutter.legacy_python == "yes" %}
 #if PY_MAJOR_VERSION < 3
 PyMODINIT_FUNC init{{ cookiecutter.c_extension_module }}(void) {
     moduleinit();
 }
 #else
+{%- endif %}
 PyMODINIT_FUNC PyInit_{{ cookiecutter.c_extension_module }}(void) {
     return moduleinit();
 }
+{%- if cookiecutter.legacy_python == "yes" %}
 #endif
+{%- endif %}
 {% endif %}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -32,7 +32,7 @@ envlist =
 {%- if cookiecutter.legacy_python == "yes" %}
     {py27,py35,py36,py37,py38,py39,pypy,pypy3}
 {%- else %}
-    {py35,py36,py37,py38,py39,pypy3}
+    {py36,py37,py38,py39,pypy3}
 {%- endif -%}
 {%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
     report
@@ -49,8 +49,8 @@ basepython =
     pypy3: {env:TOXPYTHON:pypy3}
 {%- if cookiecutter.legacy_python == "yes" %}
     py27: {env:TOXPYTHON:python2.7}
-{%- endif %}
     py35: {env:TOXPYTHON:python3.5}
+{%- endif %}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -29,7 +29,12 @@ envlist =
 {%- if cookiecutter.sphinx_docs == "yes" %}
     docs,
 {%- endif %}
-    {py27,py35,py36,py37,py38,py39,pypy,pypy3}{% if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
+{%- if cookiecutter.legacy_python == "yes" %}
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3}
+{%- else %}
+    {py35,py36,py37,py38,py39,pypy3}
+{%- endif -%}
+{%- if cookiecutter.test_matrix_separate_coverage == 'yes' %}-{cover,nocov}{% endif %},
     report
 ignore_basepython_conflict = true
 
@@ -38,9 +43,13 @@ ignore_basepython_conflict = true
 wheel = true
 {%- endif %}
 basepython =
+{%- if cookiecutter.legacy_python == "yes" %}
     pypy: {env:TOXPYTHON:pypy}
+{%- endif %}
     pypy3: {env:TOXPYTHON:pypy3}
+{%- if cookiecutter.legacy_python == "yes" %}
     py27: {env:TOXPYTHON:python2.7}
+{%- endif %}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -30,7 +30,7 @@ envlist =
     docs,
 {%- endif %}
 {%- if cookiecutter.legacy_python == "yes" %}
-    {py27,py35,py36,py37,py38,py39,pypy,pypy3}
+    {py27,py36,py37,py38,py39,pypy,pypy3}
 {%- else %}
     {py36,py37,py38,py39,pypy3}
 {%- endif -%}
@@ -49,7 +49,6 @@ basepython =
     pypy3: {env:TOXPYTHON:pypy3}
 {%- if cookiecutter.legacy_python == "yes" %}
     py27: {env:TOXPYTHON:python2.7}
-    py35: {env:TOXPYTHON:python3.5}
 {%- endif %}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}


### PR DESCRIPTION
Addresses #214 

- added `legacy_python [no|yes]` cookiecutter switch
- updates `setup.py`, c extension code, `tox.ini`
  - set python2.7 as legacy
  - remove python3.5 completely (users can add it themselves later on)
- removes old `from __future__ import ...` if python2 is disabled, from `setup.py` only - `ci/bootstrap.py` can still be called with python2 even if project targets python3 only
- added tests for cookiecutter (WIP? - should they be reduced to improve test run time)
- add/update documentation to readme

_And I agree with the LICENSE the project is under._