### PR TITLE
Use tox --sitepackages for the tox -e bootstrap call

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -124,10 +124,10 @@ if __name__ == "__main__":
     Generating CI configuration ...
 """)
     try:
-        subprocess.check_call(['tox', '-e', 'bootstrap'])
+        subprocess.check_call(['tox', '-e', 'bootstrap', '--sitepackages'])
     except Exception:
         try:
-            subprocess.check_call([sys.executable, '-mtox', '-e', 'bootstrap'])
+            subprocess.check_call([sys.executable, '-mtox', '-e', 'bootstrap', '--sitepackages'])
         except Exception:
             subprocess.check_call([sys.executable, join('ci', 'bootstrap.py')])
 


### PR DESCRIPTION
 so that tox does not hang indefinitely if there is no active Internet connection.