### PR TITLE
Insert missing space in docstrings

### DIFF
--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/cli.py
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.package_name}}/cli.py
@@ -6,7 +6,7 @@ Why does this file exist, and why not put this in __main__?
   You might be tempted to import things from __main__ later, but that will cause
   problems: the code will get executed twice:
 
-  - When you run `python -m{{cookiecutter.package_name}}` python will execute
+  - When you run `python -m {{cookiecutter.package_name}}` python will execute
     ``__main__.py`` as a script. That means there won't be any
     ``{{cookiecutter.package_name}}.__main__`` in ``sys.modules``.
   - When you import __main__ it will get executed again (as a module) because


### PR DESCRIPTION
The example python -m command is missing a space between the "-m" and the package name.