### PR TITLE
Fix toxinidir handling

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -130,7 +130,7 @@ skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
 {%- if cookiecutter.setup_py_uses_setuptools_scm == 'no' %}
-    check-manifest '{toxinidir}'
+    check-manifest .
 {%- endif %}
 {%- if cookiecutter.linter == "flake8" %}
     flake8

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -73,7 +73,7 @@ basepython =
         {%- endif -%}
     }: {env:TOXPYTHON:python3}
 setenv =
-    PYTHONPATH='{toxinidir}/tests'
+    PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
 {%- if cookiecutter.c_extension_support in ['yes', 'cython'] %}
     cover: SETUPPY_EXT_COVERAGE=yes

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -73,7 +73,7 @@ basepython =
         {%- endif -%}
     }: {env:TOXPYTHON:python3}
 setenv =
-    PYTHONPATH={toxinidir}/tests
+    PYTHONPATH='{toxinidir}/tests'
     PYTHONUNBUFFERED=yes
 {%- if cookiecutter.c_extension_support in ['yes', 'cython'] %}
     cover: SETUPPY_EXT_COVERAGE=yes
@@ -130,7 +130,7 @@ skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
 {%- if cookiecutter.setup_py_uses_setuptools_scm == 'no' %}
-    check-manifest {toxinidir}
+    check-manifest '{toxinidir}'
 {%- endif %}
 {%- if cookiecutter.linter == "flake8" %}
     flake8


### PR DESCRIPTION
Fixed references to toxinidir. When the directory contains spaces, the check-manifest command would fail because the path would be incorrectly interpreted as multiple options due to the spaces.