### PR TITLE
Add required package to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ To get quickly started on a new system, just `install setuptools
 <https://pip.pypa.io/en/latest/installing.html>`_. That's the bare minimum to required install Tox_ and Cookiecutter_. To install
 them, just run this in your shell or command prompt::
 
-  pip install tox cookiecutter
+  pip install tox cookiecutter jinja2_time
 
 Usage and options
 -----------------


### PR DESCRIPTION
I wanted to use the template on a fresh machine and had all the deps but still got error:
```
➜  cyberman cookiecutter gh:ionelmc/cookiecutter-pylibrary
Unable to load extension: No module named 'jinja2_time'
```

Solved it by just installing it, but good to have up-to-date docs 